### PR TITLE
chore: 不锁版本

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 	"dependencies": {
 		"@tauri-apps/api": "^2.10.1",
 		"@tauri-apps/plugin-clipboard-manager": "^2.3.2",
-		"@tauri-apps/plugin-dialog": "2.6.0",
+		"@tauri-apps/plugin-dialog": "^2.7.0",
 		"@vueuse/core": "^14.2.1",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^2.3.2
         version: 2.3.2
       '@tauri-apps/plugin-dialog':
-        specifier: 2.6.0
-        version: 2.6.0
+        specifier: ^2.7.0
+        version: 2.7.0
       '@vueuse/core':
         specifier: ^14.2.1
         version: 14.2.1(vue@3.5.32(typescript@6.0.2))
@@ -748,8 +748,8 @@ packages:
   '@tauri-apps/plugin-clipboard-manager@2.3.2':
     resolution: {integrity: sha512-CUlb5Hqi2oZbcZf4VUyUH53XWPPdtpw43EUpCza5HWZJwxEoDowFzNUDt1tRUXA8Uq+XPn17Ysfptip33sG4eQ==}
 
-  '@tauri-apps/plugin-dialog@2.6.0':
-    resolution: {integrity: sha512-q4Uq3eY87TdcYzXACiYSPhmpBA76shgmQswGkSVio4C82Sz2W4iehe9TnKYwbq7weHiL88Yw19XZm7v28+Micg==}
+  '@tauri-apps/plugin-dialog@2.7.0':
+    resolution: {integrity: sha512-4nS/hfGMGCXiAS3LtVjH9AgsSAPJeG/7R+q8agTFqytjnMa4Zq95Bq8WzVDkckpanX+yyRHXnRtrKXkANKDHvw==}
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
@@ -2043,7 +2043,7 @@ snapshots:
     dependencies:
       '@tauri-apps/api': 2.10.1
 
-  '@tauri-apps/plugin-dialog@2.6.0':
+  '@tauri-apps/plugin-dialog@2.7.0':
     dependencies:
       '@tauri-apps/api': 2.10.1
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Unpinned `@tauri-apps/plugin-dialog` and bumped from 2.6.0 to ^2.7.0 to allow automatic minor/patch updates. Updated pnpm lockfile to resolve `@tauri-apps/plugin-dialog` at 2.7.0.

<sup>Written for commit e50f2afc719a0a798d41f21051ba4e5964e6c9a1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the dialog plugin dependency to support a broader range of versions, enabling access to the latest improvements and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->