### PR TITLE
Add multi-chunk HTTP download resume and per-chunk progress tracking

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.4.11/schema.json",
 	"vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
 	"files": { "includes": ["**", "!!**/dist"] },
 	"formatter": { "enabled": true, "indentStyle": "tab" },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "motrix-next",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"description": "A full-featured download manager",
 	"homepage": "https://motrix.app",
 	"author": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3722,7 +3722,7 @@ dependencies = [
 
 [[package]]
 name = "motrix"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "aes",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "motrix"
-version = "0.1.1"
+version = "0.1.2"
 description = "A full-featured download manager"
 authors = ["YueMiyuki"]
 edition = "2021"

--- a/src-tauri/src/commands/file_cmds.rs
+++ b/src-tauri/src/commands/file_cmds.rs
@@ -14,6 +14,7 @@ const MAX_TORRENT_PREVIEW_BYTES: usize = 8 * 1024 * 1024;
 const DEFAULT_TORRENT_PREVIEW_PAGE_SIZE: usize = 300;
 const MAX_TORRENT_PREVIEW_PAGE_SIZE: usize = 2_000;
 const TEMP_DOWNLOAD_SUFFIX: &str = ".part";
+const CHUNK_META_SUFFIX: &str = ".chunks";
 
 #[derive(Debug)]
 enum BencodeValue {
@@ -168,9 +169,19 @@ pub fn trash_item(path: String) -> Result<bool, String> {
     let p = std::path::Path::new(&path);
     if !p.exists() {
         log::info!("trash_item: path does not exist, skipped: {}", path);
+        // Still try to clean up .chunks sidecar even if .part is gone
+        if path.ends_with(TEMP_DOWNLOAD_SUFFIX) {
+            let chunks_path = format!("{}{}", path, CHUNK_META_SUFFIX);
+            let _ = std::fs::remove_file(&chunks_path);
+        }
         return Ok(false);
     }
     trash::delete(&path).map_err(|e| e.to_string())?;
+    // Clean up multi-chunk resume sidecar alongside .part file
+    if path.ends_with(TEMP_DOWNLOAD_SUFFIX) {
+        let chunks_path = format!("{}{}", path, CHUNK_META_SUFFIX);
+        let _ = std::fs::remove_file(&chunks_path);
+    }
     Ok(true)
 }
 

--- a/src-tauri/src/commands/file_cmds.rs
+++ b/src-tauri/src/commands/file_cmds.rs
@@ -14,7 +14,7 @@ const MAX_TORRENT_PREVIEW_BYTES: usize = 8 * 1024 * 1024;
 const DEFAULT_TORRENT_PREVIEW_PAGE_SIZE: usize = 300;
 const MAX_TORRENT_PREVIEW_PAGE_SIZE: usize = 2_000;
 const TEMP_DOWNLOAD_SUFFIX: &str = ".part";
-const CHUNK_META_SUFFIX: &str = ".chunks";
+use crate::engine::CHUNK_META_SUFFIX;
 
 #[derive(Debug)]
 enum BencodeValue {

--- a/src-tauri/src/engine/http.rs
+++ b/src-tauri/src/engine/http.rs
@@ -354,11 +354,11 @@ pub async fn run_http_download(
     // Single-connection download (fallback, resume, FTP, or small files)
     // If falling through from a failed multi-chunk probe and a pre-allocated .part exists,
     // its size doesn't reflect actual download progress — remove it to avoid a 416.
-    if split > 1 && existing_size > 0 {
+    // Only remove when chunk metadata confirms this is a multi-chunk artifact
+    if chunk_meta_path(&part_path).exists() && existing_size > 0 {
         tracing::info!("Removing pre-allocated .part before single-connection fallback");
         let _ = fs::remove_file(&part_path);
         delete_chunk_meta(&part_path);
-        let _ = fs::remove_file(&part_path);
     }
     connections.store(1, Ordering::Relaxed);
     let result = run_single_download(
@@ -560,18 +560,6 @@ async fn run_multi_chunk(
 ) -> Result<PathBuf, String> {
     total.store(content_length, Ordering::Relaxed);
 
-    // Pre-allocate the output file (no-op if already at correct size)
-    {
-        let file = fs::OpenOptions::new()
-            .create(true)
-            .write(true)
-            .truncate(false)
-            .open(part_path)
-            .map_err(|e| format!("Failed to create file: {e}"))?;
-        file.set_len(content_length)
-            .map_err(|e| format!("Failed to pre-allocate file: {e}"))?;
-    }
-
     tracing::info!("Multi-chunk download: {split} chunks, {content_length} bytes total");
 
     // Calculate chunk boundaries
@@ -587,7 +575,7 @@ async fn run_multi_chunk(
         chunks.push(ChunkRange::new(start, end));
     }
 
-    // Check for existing chunk progress from a previous paused/failed attempt
+    // Load resume sidecar BEFORE pre-allocating so the file-size check is meaningful
     let initial_offsets =
         if let Some(meta) = load_chunk_meta(part_path, content_length, split, &expected_etag) {
             let total_resumed: u64 = meta.chunk_bytes.iter().sum();
@@ -604,6 +592,18 @@ async fn run_multi_chunk(
         } else {
             vec![0u64; split]
         };
+
+    // Pre-allocate the output file AFTER sidecar validation
+    {
+        let file = fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(false)
+            .open(part_path)
+            .map_err(|e| format!("Failed to create file: {e}"))?;
+        file.set_len(content_length)
+            .map_err(|e| format!("Failed to pre-allocate file: {e}"))?;
+    }
 
     let file = tokio::fs::OpenOptions::new()
         .write(true)
@@ -822,6 +822,44 @@ async fn download_chunk_stream(
         };
     }
 
+    // enforce 206 Partial Content with matching Content-Range
+    if status != 206 {
+        return StreamOutcome {
+            bytes_flushed: 0,
+            error: Some(format!(
+                "Expected 206 Partial Content with matching Content-Range, got {status}"
+            )),
+        };
+    }
+    if let Some(cr) = resp.headers().get(CONTENT_RANGE).and_then(|v| v.to_str().ok()) {
+        // Content-Range: bytes START-END/TOTAL
+        if let Some(space) = cr.find(' ') {
+            if let Some(dash) = cr[space + 1..].find('-') {
+                if let Ok(range_start) = cr[space + 1..space + 1 + dash].parse::<u64>() {
+                    if range_start != range.start {
+                        return StreamOutcome {
+                            bytes_flushed: 0,
+                            error: Some(format!(
+                                "Expected 206 Partial Content with matching Content-Range: \
+                                 requested start {} but got {range_start}",
+                                range.start
+                            )),
+                        };
+                    }
+                }
+            }
+        }
+    } else {
+        return StreamOutcome {
+            bytes_flushed: 0,
+            error: Some(
+                "Expected 206 Partial Content with matching Content-Range, \
+                 but Content-Range header is missing"
+                    .to_string(),
+            ),
+        };
+    }
+
     let mut stream = resp.bytes_stream();
     let mut buf = Vec::with_capacity(CHUNK_BUF_CAPACITY);
     let mut total_written: u64 = 0;
@@ -906,6 +944,10 @@ async fn download_chunk_stream(
                                     total_written += written as u64;
                                 }
                                 Err(e) => {
+                                    completed.fetch_sub(buf.len() as u64, Ordering::Relaxed);
+                                    if let Some(cc) = chunk_completed {
+                                        cc.fetch_sub(buf.len() as u64, Ordering::Relaxed);
+                                    }
                                     return StreamOutcome {
                                         bytes_flushed: total_written,
                                         error: Some(e),

--- a/src-tauri/src/engine/http.rs
+++ b/src-tauri/src/engine/http.rs
@@ -28,7 +28,7 @@ const STALE_PART_REMOVED: &str = "stale partial file removed";
 /// Exponential moving average smoothing factor for speed reporting
 const SPEED_EMA_ALPHA: f64 = 0.3;
 /// Suffix for per-chunk resume metadata file
-const CHUNK_META_SUFFIX: &str = ".chunks";
+use super::CHUNK_META_SUFFIX;
 
 /// Inclusive byte range [start, end]
 #[derive(Debug, Clone, Copy)]
@@ -112,6 +112,21 @@ fn load_chunk_meta(
         let _ = fs::remove_file(&path);
         return None;
     }
+
+    // Verify the .part file exists with the expected pre-allocated size
+    match fs::metadata(part_path) {
+        Ok(m) if m.len() == content_length => {}
+        _ => {
+            let _ = fs::remove_file(&path);
+            return None;
+        }
+    }
+
+    // Saved ETag without a current probe ETag means we can't verify integrity
+    if meta.etag.is_some() && etag.is_none() {
+        let _ = fs::remove_file(&path);
+        return None;
+    }
     // If both have ETags, they must match (server file unchanged)
     if let (Some(saved), Some(current)) = (&meta.etag, etag) {
         if saved != current {
@@ -119,6 +134,21 @@ fn load_chunk_meta(
             return None;
         }
     }
+
+    // Bounds-check each chunk's saved bytes against its real length
+    let chunk_size = content_length / split as u64;
+    for (i, &bytes) in meta.chunk_bytes.iter().enumerate() {
+        let chunk_len = if i == split - 1 {
+            content_length - chunk_size * (split as u64 - 1)
+        } else {
+            chunk_size
+        };
+        if bytes > chunk_len {
+            let _ = fs::remove_file(&path);
+            return None;
+        }
+    }
+
     Some(meta)
 }
 
@@ -695,6 +725,7 @@ async fn download_chunk(
             global_limiter,
             task_limiter,
             expected_etag,
+            chunk_completed,
         )
         .await;
 
@@ -746,6 +777,7 @@ async fn download_chunk_stream(
     global_limiter: &SpeedLimiter,
     task_limiter: &SpeedLimiter,
     expected_etag: Option<&str>,
+    chunk_completed: Option<&Arc<AtomicU64>>,
 ) -> StreamOutcome {
     let mut req = client
         .get(uri)
@@ -803,6 +835,9 @@ async fn download_chunk_stream(
                     } else {
                         // Flush failed; revert the received-bytes from `completed`
                         completed.fetch_sub(buf.len() as u64, Ordering::Relaxed);
+                        if let Some(cc) = chunk_completed {
+                            cc.fetch_sub(buf.len() as u64, Ordering::Relaxed);
+                        }
                     }
                 }
                 return StreamOutcome {
@@ -819,6 +854,9 @@ async fn download_chunk_stream(
 
                         buf.extend_from_slice(&bytes);
                         completed.fetch_add(len as u64, Ordering::Relaxed);
+                        if let Some(cc) = chunk_completed {
+                            cc.fetch_add(len as u64, Ordering::Relaxed);
+                        }
 
                         if buf.len() >= CHUNK_BUF_CAPACITY {
                             match flush_buf_at(
@@ -829,6 +867,10 @@ async fn download_chunk_stream(
                                     buf.clear();
                                 }
                                 Err(e) => {
+                                    completed.fetch_sub(buf.len() as u64, Ordering::Relaxed);
+                                    if let Some(cc) = chunk_completed {
+                                        cc.fetch_sub(buf.len() as u64, Ordering::Relaxed);
+                                    }
                                     return StreamOutcome {
                                         bytes_flushed: total_written,
                                         error: Some(e),
@@ -845,6 +887,9 @@ async fn download_chunk_stream(
                                 total_written += n as u64;
                             } else {
                                 completed.fetch_sub(buf.len() as u64, Ordering::Relaxed);
+                                if let Some(cc) = chunk_completed {
+                                    cc.fetch_sub(buf.len() as u64, Ordering::Relaxed);
+                                }
                             }
                         }
                         return StreamOutcome {

--- a/src-tauri/src/engine/http.rs
+++ b/src-tauri/src/engine/http.rs
@@ -27,6 +27,8 @@ const CHUNK_MAX_RETRIES: u32 = 5;
 const STALE_PART_REMOVED: &str = "stale partial file removed";
 /// Exponential moving average smoothing factor for speed reporting
 const SPEED_EMA_ALPHA: f64 = 0.3;
+/// Suffix for per-chunk resume metadata file
+const CHUNK_META_SUFFIX: &str = ".chunks";
 
 /// Inclusive byte range [start, end]
 #[derive(Debug, Clone, Copy)]
@@ -50,8 +52,92 @@ impl ChunkRange {
     }
 }
 
+/// Outcome from a single stream call: always reports bytes flushed to disk.
+struct StreamOutcome {
+    bytes_flushed: u64,
+    error: Option<String>,
+}
+
+/// Metadata for resuming multi-chunk downloads, persisted as a JSON sidecar.
+#[derive(serde::Serialize, serde::Deserialize)]
+struct ChunkMeta {
+    content_length: u64,
+    split: usize,
+    etag: Option<String>,
+    /// Per-chunk bytes confirmed flushed to disk
+    chunk_bytes: Vec<u64>,
+}
+
+fn chunk_meta_path(part_path: &Path) -> PathBuf {
+    let mut p = part_path.as_os_str().to_owned();
+    p.push(CHUNK_META_SUFFIX);
+    PathBuf::from(p)
+}
+
+fn save_chunk_meta(
+    part_path: &Path,
+    content_length: u64,
+    split: usize,
+    etag: &Option<String>,
+    chunk_completed: &[Arc<AtomicU64>],
+) {
+    let meta = ChunkMeta {
+        content_length,
+        split,
+        etag: etag.clone(),
+        chunk_bytes: chunk_completed
+            .iter()
+            .map(|c| c.load(Ordering::Relaxed))
+            .collect(),
+    };
+    let path = chunk_meta_path(part_path);
+    if let Ok(json) = serde_json::to_string(&meta) {
+        let _ = fs::write(&path, json);
+    }
+}
+
+fn load_chunk_meta(
+    part_path: &Path,
+    content_length: u64,
+    split: usize,
+    etag: &Option<String>,
+) -> Option<ChunkMeta> {
+    let path = chunk_meta_path(part_path);
+    let data = fs::read_to_string(&path).ok()?;
+    let meta: ChunkMeta = serde_json::from_str(&data).ok()?;
+    if meta.content_length != content_length
+        || meta.split != split
+        || meta.chunk_bytes.len() != split
+    {
+        let _ = fs::remove_file(&path);
+        return None;
+    }
+    // If both have ETags, they must match (server file unchanged)
+    if let (Some(saved), Some(current)) = (&meta.etag, etag) {
+        if saved != current {
+            let _ = fs::remove_file(&path);
+            return None;
+        }
+    }
+    Some(meta)
+}
+
+fn delete_chunk_meta(part_path: &Path) {
+    let _ = fs::remove_file(chunk_meta_path(part_path));
+}
+
 /// Build a reqwest Client with common settings applied from options
 fn build_client(options: &Map<String, Value>) -> Result<Client, String> {
+    build_client_inner(options, true)
+}
+
+/// Build a client without automatic decompression — needed for range requests
+/// where we must receive raw bytes at exact file offsets.
+fn build_client_no_decompress(options: &Map<String, Value>) -> Result<Client, String> {
+    build_client_inner(options, false)
+}
+
+fn build_client_inner(options: &Map<String, Value>, decompress: bool) -> Result<Client, String> {
     let ua = options
         .get("user-agent")
         .and_then(|v| v.as_str())
@@ -61,10 +147,13 @@ fn build_client(options: &Map<String, Value>) -> Result<Client, String> {
         .user_agent(ua)
         .redirect(reqwest::redirect::Policy::limited(10))
         .connect_timeout(std::time::Duration::from_secs(30))
-        .tcp_nodelay(true)
-        .gzip(true)
-        .brotli(true)
-        .deflate(true);
+        .tcp_nodelay(true);
+
+    if decompress {
+        builder = builder.gzip(true).brotli(true).deflate(true);
+    } else {
+        builder = builder.no_gzip().no_brotli().no_deflate();
+    }
 
     if let Some(proxy_url) = options
         .get("all-proxy")
@@ -139,6 +228,7 @@ pub async fn run_http_download(
     cancel_token: CancellationToken,
     global_limiter: Arc<SpeedLimiter>,
     task_limiter: Arc<SpeedLimiter>,
+    chunk_completed: Vec<Arc<AtomicU64>>,
 ) -> Result<PathBuf, String> {
     tracing::info!("Starting download: uri={uri}, dir={dir}, out={out}");
     let dir_path = Path::new(dir);
@@ -164,6 +254,11 @@ pub async fn run_http_download(
         .max(1) as usize;
 
     let client = build_client(options)?;
+    let range_client = if split > 1 {
+        build_client_no_decompress(options)?
+    } else {
+        client.clone()
+    };
     let headers = build_headers(options);
 
     let use_remote_time = options
@@ -181,7 +276,7 @@ pub async fn run_http_download(
     let mut last_modified_header: Option<String> = None;
 
     let is_http = uri.starts_with("http://") || uri.starts_with("https://");
-    if is_http && split > 1 && existing_size == 0 {
+    if is_http && split > 1 {
         match probe_range_support(&client, uri, &headers).await {
             Ok(Some(probe)) if probe.content_length > MIN_SEGMENT_SIZE * split as u64 => {
                 if use_remote_time {
@@ -189,7 +284,7 @@ pub async fn run_http_download(
                 }
                 connections.store(split as u32, Ordering::Relaxed);
                 let result = run_multi_chunk(
-                    &client,
+                    &range_client,
                     uri,
                     &part_path,
                     probe.content_length,
@@ -204,6 +299,7 @@ pub async fn run_http_download(
                     global_limiter,
                     task_limiter,
                     probe.etag,
+                    &chunk_completed,
                 )
                 .await;
                 if let Ok(ref path) = result {
@@ -226,6 +322,14 @@ pub async fn run_http_download(
     }
 
     // Single-connection download (fallback, resume, FTP, or small files)
+    // If falling through from a failed multi-chunk probe and a pre-allocated .part exists,
+    // its size doesn't reflect actual download progress — remove it to avoid a 416.
+    if split > 1 && existing_size > 0 {
+        tracing::info!("Removing pre-allocated .part before single-connection fallback");
+        let _ = fs::remove_file(&part_path);
+        delete_chunk_meta(&part_path);
+        let _ = fs::remove_file(&part_path);
+    }
     connections.store(1, Ordering::Relaxed);
     let result = run_single_download(
         &client,
@@ -248,9 +352,13 @@ pub async fn run_http_download(
     let final_result = match result {
         Err(ref e) if e.contains(STALE_PART_REMOVED) => {
             tracing::info!("Retrying download after stale .part removal");
+            delete_chunk_meta(&part_path);
             completed.store(0, Ordering::Relaxed);
             total.store(0, Ordering::Relaxed);
             speed.store(0, Ordering::Relaxed);
+            for cc in &chunk_completed {
+                cc.store(0, Ordering::Relaxed);
+            }
 
             if is_http && split > 1 {
                 if let Ok(Some(probe)) =
@@ -262,7 +370,7 @@ pub async fn run_http_download(
                         }
                         connections.store(split as u32, Ordering::Relaxed);
                         let mc_result = run_multi_chunk(
-                            &client,
+                            &range_client,
                             uri,
                             &part_path,
                             probe.content_length,
@@ -277,6 +385,7 @@ pub async fn run_http_download(
                             global_limiter,
                             task_limiter,
                             probe.etag,
+                            &chunk_completed,
                         )
                         .await;
                         if let Ok(ref path) = mc_result {
@@ -417,10 +526,11 @@ async fn run_multi_chunk(
     global_limiter: Arc<SpeedLimiter>,
     task_limiter: Arc<SpeedLimiter>,
     expected_etag: Option<String>,
+    chunk_completed: &[Arc<AtomicU64>],
 ) -> Result<PathBuf, String> {
     total.store(content_length, Ordering::Relaxed);
 
-    // Pre-allocate the output file
+    // Pre-allocate the output file (no-op if already at correct size)
     {
         let file = fs::OpenOptions::new()
             .create(true)
@@ -447,6 +557,24 @@ async fn run_multi_chunk(
         chunks.push(ChunkRange::new(start, end));
     }
 
+    // Check for existing chunk progress from a previous paused/failed attempt
+    let initial_offsets =
+        if let Some(meta) = load_chunk_meta(part_path, content_length, split, &expected_etag) {
+            let total_resumed: u64 = meta.chunk_bytes.iter().sum();
+            completed.store(total_resumed, Ordering::Relaxed);
+            for (i, &bytes) in meta.chunk_bytes.iter().enumerate() {
+                if let Some(cc) = chunk_completed.get(i) {
+                    cc.store(bytes, Ordering::Relaxed);
+                }
+            }
+            tracing::info!(
+                "Resuming multi-chunk download: {total_resumed}/{content_length} bytes"
+            );
+            meta.chunk_bytes
+        } else {
+            vec![0u64; split]
+        };
+
     let file = tokio::fs::OpenOptions::new()
         .write(true)
         .open(part_path)
@@ -466,6 +594,12 @@ async fn run_multi_chunk(
     // Spawn all chunk downloads concurrently
     let mut futures = futures_util::stream::FuturesUnordered::new();
     for (i, chunk) in chunks.iter().enumerate() {
+        let initial = initial_offsets[i];
+        // Skip chunks already fully downloaded
+        if initial >= chunk.len() {
+            continue;
+        }
+
         let client = client.clone();
         let uri = uri.to_string();
         let headers = headers.clone();
@@ -476,9 +610,10 @@ async fn run_multi_chunk(
         let gl = global_limiter.clone();
         let tl = task_limiter.clone();
         let etag = expected_etag.clone();
+        let cc = chunk_completed.get(i).cloned();
 
         futures.push(tokio::spawn(async move {
-            download_chunk(&client, &uri, &headers, chunk, &file, &completed, cancel_token, i, &gl, &tl, etag.as_deref())
+            download_chunk(&client, &uri, &headers, chunk, &file, &completed, cancel_token, i, &gl, &tl, etag.as_deref(), cc.as_ref(), initial)
                 .await
         }));
     }
@@ -498,6 +633,9 @@ async fn run_multi_chunk(
     speed.store(0, Ordering::Relaxed);
 
     if !errors.is_empty() {
+        // Persist per-chunk progress for potential resume
+        save_chunk_meta(part_path, content_length, split, &expected_etag, chunk_completed);
+
         if errors.iter().all(|e| e.contains("cancelled")) {
             return Err("Download cancelled".to_string());
         }
@@ -512,6 +650,7 @@ async fn run_multi_chunk(
         }
     }
 
+    delete_chunk_meta(part_path);
     finalize_download(part_path, filename, dir_path)
 }
 
@@ -528,8 +667,10 @@ async fn download_chunk(
     global_limiter: &SpeedLimiter,
     task_limiter: &SpeedLimiter,
     expected_etag: Option<&str>,
+    chunk_completed: Option<&Arc<AtomicU64>>,
+    initial_bytes_written: u64,
 ) -> Result<(), String> {
-    let mut bytes_written: u64 = 0;
+    let mut bytes_written: u64 = initial_bytes_written;
     let mut retry_count: u32 = 0;
 
     loop {
@@ -543,7 +684,7 @@ async fn download_chunk(
         }
 
         let current_range = ChunkRange::new(current_start, chunk.end);
-        let result = download_chunk_stream(
+        let outcome = download_chunk_stream(
             client,
             uri,
             headers,
@@ -557,19 +698,24 @@ async fn download_chunk(
         )
         .await;
 
-        match result {
-            Ok(written) => {
-                bytes_written += written;
+        // Always account for bytes confirmed flushed to disk
+        bytes_written += outcome.bytes_flushed;
+        if let Some(cc) = chunk_completed {
+            cc.store(bytes_written, Ordering::Relaxed);
+        }
+
+        match outcome.error {
+            None => {
                 if bytes_written >= chunk.len() {
                     return Ok(());
                 }
                 // Partial success, continue to download the rest of the chunk
                 retry_count = 0;
             }
-            Err(e) if e.contains("cancelled") => {
+            Some(e) if e.contains("cancelled") => {
                 return Err(e);
             }
-            Err(e) => {
+            Some(e) => {
                 retry_count += 1;
                 if retry_count > CHUNK_MAX_RETRIES {
                     return Err(format!(
@@ -587,7 +733,8 @@ async fn download_chunk(
     }
 }
 
-/// Stream a chunk range. Returns bytes successfully written to disk
+/// Stream a chunk range. Always returns the number of bytes flushed to disk,
+/// even on error, so the caller can accurately track resume progress.
 async fn download_chunk_stream(
     client: &Client,
     uri: &str,
@@ -599,38 +746,48 @@ async fn download_chunk_stream(
     global_limiter: &SpeedLimiter,
     task_limiter: &SpeedLimiter,
     expected_etag: Option<&str>,
-) -> Result<u64, String> {
+) -> StreamOutcome {
     let mut req = client
         .get(uri)
         .headers(headers.clone())
         .header(RANGE, range.to_range_header_value());
 
-    // If we have an ETag from the probe, send If-Match to ensure the file hasn't changed
-    // If the ETag no longer matches, the server returns 412 Precondition Failed
     if let Some(etag) = expected_etag {
         if let Ok(v) = HeaderValue::from_str(etag) {
             req = req.header(IF_MATCH, v);
         }
     }
 
-    let resp = req
-        .send()
-        .await
-        .map_err(|e| format!("HTTP request failed: {e}"))?;
+    let resp = match req.send().await {
+        Ok(r) => r,
+        Err(e) => {
+            return StreamOutcome {
+                bytes_flushed: 0,
+                error: Some(format!("HTTP request failed: {e}")),
+            };
+        }
+    };
 
     let status = resp.status().as_u16();
 
-    // For range requests, validate that the ETag still matches
     if let Some(expected) = expected_etag {
         if let Some(actual) = resp.headers().get(ETAG).and_then(|v| v.to_str().ok()) {
             if actual != expected {
-                return Err("Server file changed (ETag mismatch), aborting download".to_string());
+                return StreamOutcome {
+                    bytes_flushed: 0,
+                    error: Some(
+                        "Server file changed (ETag mismatch), aborting download".to_string(),
+                    ),
+                };
             }
         }
     }
 
     if status >= 400 {
-        return Err(format!("HTTP error: {status}"));
+        return StreamOutcome {
+            bytes_flushed: 0,
+            error: Some(format!("HTTP error: {status}")),
+        };
     }
 
     let mut stream = resp.bytes_stream();
@@ -641,16 +798,22 @@ async fn download_chunk_stream(
         tokio::select! {
             _ = cancel_token.cancelled() => {
                 if !buf.is_empty() {
-                    flush_buf_at(file, range.start + total_written, &buf).await?;
+                    if let Ok(n) = flush_buf_at(file, range.start + total_written, &buf).await {
+                        total_written += n as u64;
+                    } else {
+                        // Flush failed; revert the received-bytes from `completed`
+                        completed.fetch_sub(buf.len() as u64, Ordering::Relaxed);
+                    }
                 }
-                return Err("Download cancelled".to_string());
+                return StreamOutcome {
+                    bytes_flushed: total_written,
+                    error: Some("Download cancelled".to_string()),
+                };
             }
             chunk = stream.next() => {
                 match chunk {
                     Some(Ok(bytes)) => {
                         let len = bytes.len();
-
-                        // Apply speed limits before accounting for the bytes
                         global_limiter.acquire(len).await;
                         task_limiter.acquire(len).await;
 
@@ -658,29 +821,57 @@ async fn download_chunk_stream(
                         completed.fetch_add(len as u64, Ordering::Relaxed);
 
                         if buf.len() >= CHUNK_BUF_CAPACITY {
-                            let written = flush_buf_at(
+                            match flush_buf_at(
                                 file, range.start + total_written, &buf,
-                            ).await?;
-                            total_written += written as u64;
-                            buf.clear();
+                            ).await {
+                                Ok(written) => {
+                                    total_written += written as u64;
+                                    buf.clear();
+                                }
+                                Err(e) => {
+                                    return StreamOutcome {
+                                        bytes_flushed: total_written,
+                                        error: Some(e),
+                                    };
+                                }
+                            }
                         }
                     }
                     Some(Err(e)) => {
                         if !buf.is_empty() {
-                            flush_buf_at(
+                            if let Ok(n) = flush_buf_at(
                                 file, range.start + total_written, &buf,
-                            ).await?;
+                            ).await {
+                                total_written += n as u64;
+                            } else {
+                                completed.fetch_sub(buf.len() as u64, Ordering::Relaxed);
+                            }
                         }
-                        return Err(format!("Stream error: {e}"));
+                        return StreamOutcome {
+                            bytes_flushed: total_written,
+                            error: Some(format!("Stream error: {e}")),
+                        };
                     }
                     None => {
                         if !buf.is_empty() {
-                            let written = flush_buf_at(
+                            match flush_buf_at(
                                 file, range.start + total_written, &buf,
-                            ).await?;
-                            total_written += written as u64;
+                            ).await {
+                                Ok(written) => {
+                                    total_written += written as u64;
+                                }
+                                Err(e) => {
+                                    return StreamOutcome {
+                                        bytes_flushed: total_written,
+                                        error: Some(e),
+                                    };
+                                }
+                            }
                         }
-                        return Ok(total_written);
+                        return StreamOutcome {
+                            bytes_flushed: total_written,
+                            error: None,
+                        };
                     }
                 }
             }

--- a/src-tauri/src/engine/manager.rs
+++ b/src-tauri/src/engine/manager.rs
@@ -11,7 +11,7 @@ use super::http;
 use super::options::EngineOptions;
 use super::session::SessionManager;
 use super::speed_limiter::{parse_speed_limit, SpeedLimiter};
-use super::task::{generate_gid, DownloadFile, DownloadTask, FileUri, TaskKind, TaskStatus};
+use super::task::{generate_gid, ChunkProgress, DownloadFile, DownloadTask, FileUri, TaskKind, TaskStatus};
 use super::torrent::TorrentEngine;
 
 struct ActiveDownload {
@@ -21,6 +21,8 @@ struct ActiveDownload {
     completed: Arc<AtomicU64>,
     speed: Arc<AtomicU64>,
     connections: Arc<AtomicU32>,
+    /// Split chunk completed bytes for multi-thread HTTP downloads
+    chunk_completed: Vec<Arc<AtomicU64>>,
 }
 
 pub struct TaskManager {
@@ -405,7 +407,7 @@ impl TaskManager {
             .unwrap_or(1)
             .max(1) as u32;
 
-        // Per-task speed limit from merged options
+        // split task speed limit from merged options
         let per_task_limit = merged_options
             .get("max-download-limit")
             .map(parse_speed_limit)
@@ -419,6 +421,12 @@ impl TaskManager {
         let completed = Arc::new(AtomicU64::new(0));
         let speed = Arc::new(AtomicU64::new(0));
         let connections = Arc::new(AtomicU32::new(split));
+
+        // split chunk progress atomics for multi-thread downloads
+        let chunk_completed: Vec<Arc<AtomicU64>> = (0..split)
+            .map(|_| Arc::new(AtomicU64::new(0)))
+            .collect();
+        let chunk_completed_dl = chunk_completed.clone();
 
         let cancel_dl = cancel.clone();
         let cancel_token_dl = cancel_token.clone();
@@ -442,6 +450,7 @@ impl TaskManager {
                 completed,
                 speed,
                 connections,
+                chunk_completed,
             };
             active_for_insert.write().await.insert(gid_for_insert, ad);
 
@@ -458,6 +467,7 @@ impl TaskManager {
                 cancel_token_dl,
                 global_limiter,
                 task_speed_limiter,
+                chunk_completed_dl,
             )
             .await;
 
@@ -558,6 +568,7 @@ impl TaskManager {
                 completed,
                 speed,
                 connections,
+                chunk_completed: Vec::new(),
             };
             active_for_insert.write().await.insert(gid_for_insert, ad);
 
@@ -689,6 +700,7 @@ impl TaskManager {
                 completed,
                 speed,
                 connections,
+                chunk_completed: Vec::new(),
             };
             active_for_insert.write().await.insert(gid_for_insert, ad);
 
@@ -809,6 +821,7 @@ impl TaskManager {
                 completed,
                 speed,
                 connections,
+                chunk_completed: Vec::new(),
             };
             active_for_insert.write().await.insert(gid_for_insert, ad);
 
@@ -901,6 +914,31 @@ impl TaskManager {
                     task.completed_length = ad.completed.load(Ordering::Relaxed);
                     task.download_speed = ad.speed.load(Ordering::Relaxed);
                     task.connections = ad.connections.load(Ordering::Relaxed);
+
+                    // split chunk progress for multi-thread HTTP
+                    if !ad.chunk_completed.is_empty() && task.total_length > 0 {
+                        let split = ad.chunk_completed.len() as u64;
+                        let chunk_size = task.total_length / split;
+                        task.chunk_progress = ad
+                            .chunk_completed
+                            .iter()
+                            .enumerate()
+                            .map(|(i, cc)| {
+                                let total = if i as u64 == split - 1 {
+                                    task.total_length - chunk_size * (split - 1)
+                                } else {
+                                    chunk_size
+                                };
+                                ChunkProgress {
+                                    completed: cc.load(Ordering::Relaxed),
+                                    total,
+                                }
+                            })
+                            .collect();
+                    } else {
+                        task.chunk_progress.clear();
+                    }
+
                     if let Some(f) = task.files.first_mut() {
                         f.length = task.total_length.to_string();
                         f.completed_length = task.completed_length.to_string();

--- a/src-tauri/src/engine/manager.rs
+++ b/src-tauri/src/engine/manager.rs
@@ -427,6 +427,7 @@ impl TaskManager {
             .map(|_| Arc::new(AtomicU64::new(0)))
             .collect();
         let chunk_completed_dl = chunk_completed.clone();
+        let chunk_completed_ref = chunk_completed.clone();
 
         let cancel_dl = cancel.clone();
         let cancel_token_dl = cancel_token.clone();
@@ -434,6 +435,7 @@ impl TaskManager {
         let completed_dl = completed.clone();
         let speed_dl = speed.clone();
         let connections_dl = connections.clone();
+        let connections_ref = connections.clone();
 
         let total_ref = total.clone();
         let completed_ref = completed.clone();
@@ -477,6 +479,30 @@ impl TaskManager {
                 task.total_length = total_ref.load(Ordering::Relaxed);
                 task.completed_length = completed_ref.load(Ordering::Relaxed);
                 task.download_speed = 0;
+
+                // Snapshot final per-chunk progress before the active download is removed
+                let conns = connections_ref.load(Ordering::Relaxed);
+                if chunk_completed_ref.len() > 1 && task.total_length > 0 && conns > 1 {
+                    let split_count = chunk_completed_ref.len() as u64;
+                    let chunk_size = task.total_length / split_count;
+                    task.chunk_progress = chunk_completed_ref
+                        .iter()
+                        .enumerate()
+                        .map(|(i, cc)| {
+                            let total = if i as u64 == split_count - 1 {
+                                task.total_length - chunk_size * (split_count - 1)
+                            } else {
+                                chunk_size
+                            };
+                            ChunkProgress {
+                                completed: cc.load(Ordering::Relaxed),
+                                total,
+                            }
+                        })
+                        .collect();
+                } else {
+                    task.chunk_progress.clear();
+                }
 
                 match download_result {
                     Ok(path) => {
@@ -916,7 +942,10 @@ impl TaskManager {
                     task.connections = ad.connections.load(Ordering::Relaxed);
 
                     // split chunk progress for multi-thread HTTP
-                    if !ad.chunk_completed.is_empty() && task.total_length > 0 {
+                    // Only populate when actually using multiple connections;
+                    // single-connection fallback leaves chunk_completed at zero.
+                    let conns = ad.connections.load(Ordering::Relaxed);
+                    if !ad.chunk_completed.is_empty() && task.total_length > 0 && conns > 1 {
                         let split = ad.chunk_completed.len() as u64;
                         let chunk_size = task.total_length / split;
                         task.chunk_progress = ad

--- a/src-tauri/src/engine/mod.rs
+++ b/src-tauri/src/engine/mod.rs
@@ -14,6 +14,9 @@ pub mod torrent;
 
 pub use session::SESSION_FILENAME;
 
+/// Suffix for per-chunk resume metadata sidecar file
+pub const CHUNK_META_SUFFIX: &str = ".chunks";
+
 use std::path::PathBuf;
 use std::sync::Arc;
 use tauri::AppHandle;

--- a/src-tauri/src/engine/task.rs
+++ b/src-tauri/src/engine/task.rs
@@ -78,6 +78,12 @@ pub struct PeerInfo {
     pub seeder: String,
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct ChunkProgress {
+    pub completed: u64,
+    pub total: u64,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DownloadTask {
     pub gid: String,
@@ -108,6 +114,9 @@ pub struct DownloadTask {
     /// Timestamp (ms) when seeding started, 0 if not seeding
     #[serde(default)]
     pub seeding_since: u64,
+    /// split progress for multi-thread HTTP downloads (transient)
+    #[serde(skip, default)]
+    pub chunk_progress: Vec<ChunkProgress>,
 }
 
 impl DownloadTask {
@@ -171,6 +180,7 @@ impl DownloadTask {
             peers: Vec::new(),
             created_at: now_ms(),
             seeding_since: 0,
+            chunk_progress: Vec::new(),
         }
     }
 
@@ -205,6 +215,7 @@ impl DownloadTask {
             peers: Vec::new(),
             created_at: now_ms(),
             seeding_since: 0,
+            chunk_progress: Vec::new(),
         }
     }
 
@@ -268,6 +279,7 @@ impl DownloadTask {
             peers: Vec::new(),
             created_at: now_ms(),
             seeding_since: 0,
+            chunk_progress: Vec::new(),
         }
     }
 
@@ -330,6 +342,7 @@ impl DownloadTask {
             peers: Vec::new(),
             created_at: now_ms(),
             seeding_since: 0,
+            chunk_progress: Vec::new(),
         }
     }
 
@@ -383,6 +396,7 @@ impl DownloadTask {
             peers: Vec::new(),
             created_at: now_ms(),
             seeding_since: 0,
+            chunk_progress: Vec::new(),
         }
     }
 
@@ -466,6 +480,21 @@ impl DownloadTask {
             if let Some(uri) = self.uris.first() {
                 m.insert("m3u8Link".into(), Value::String(uri.clone()));
             }
+        }
+
+        // Per-chunk progress for multi-thread HTTP downloads
+        if !self.chunk_progress.is_empty() {
+            let chunks: Vec<Value> = self
+                .chunk_progress
+                .iter()
+                .map(|cp| {
+                    let mut cm = Map::new();
+                    cm.insert("completedLength".into(), Value::String(cp.completed.to_string()));
+                    cm.insert("totalLength".into(), Value::String(cp.total.to_string()));
+                    Value::Object(cm)
+                })
+                .collect();
+            m.insert("chunkProgress".into(), Value::Array(chunks));
         }
 
         Value::Object(m)

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
 	"productName": "Motrix",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"identifier": "app.motrix.native",
 	"build": {
 		"devUrl": "http://127.0.0.1:9080",

--- a/src/renderer/components/Native/EngineClient.vue
+++ b/src/renderer/components/Native/EngineClient.vue
@@ -704,6 +704,7 @@ export default {
 				const jobs: Array<Promise<unknown>> = [
 					useAppStore().fetchGlobalStat(),
 					useAppStore().fetchProgress(),
+					useTaskStore().sampleActiveSpeeds(),
 				];
 				let activeTasksForLowSpeedCheck: Pick<
 					DownloadTask,

--- a/src/renderer/components/Task/AddTask.vue
+++ b/src/renderer/components/Task/AddTask.vue
@@ -77,7 +77,7 @@
           </div>
           <div class="atd-field atd-field--narrow">
             <label class="atd-field-label">{{ $t('task.task-split') }}</label>
-            <NumberInput v-model="form.split" :min="1" />
+            <NumberInput v-model="form.split" :min="1" :max="128" />
           </div>
           <div class="atd-field atd-field--full">
             <label class="atd-field-label">{{ $t('task.task-dir') }}</label>

--- a/src/renderer/components/TaskDetail/TaskActivity.vue
+++ b/src/renderer/components/TaskDetail/TaskActivity.vue
@@ -64,13 +64,13 @@
       </div>
     </div>
 
-    <!-- Piece graphic (BT only) -->
-    <div class="graphic-box" ref="graphicBox" v-if="isBT">
+    <!-- Piece graphic (BT or split HTTP) -->
+    <div class="graphic-box" ref="graphicBox" v-if="isBT || hasChunkProgress">
       <mo-task-graphic
         :outerWidth="graphicWidth"
         :bitfield="task.bitfield"
-        :cellCount="graphicCellCount"
-        :cellPercents="splitProgressPercents"
+        :cellCount="displayGraphicCellCount"
+        :cellPercents="displaySplitPercents"
         v-if="graphicWidth > 0"
       />
     </div>
@@ -92,13 +92,13 @@
         :total="Number(task.totalLength)"
         :status="taskStatus"
       />
-      <div class="split-progress-list" v-if="isBT && splitProgressList.length > 0">
+      <div class="split-progress-list" v-if="displaySplitProgressList.length > 0">
         <div
           class="split-progress-item"
-          v-for="item in splitProgressList"
+          v-for="item in displaySplitProgressList"
           :key="`split-${item.index}`"
         >
-          <span class="split-progress-label">S{{ item.index + 1 }}</span>
+          <span class="split-progress-label">{{ hasChunkProgress && !isBT ? 'T' : 'S' }}{{ item.index + 1 }}</span>
           <div class="split-progress-track">
             <div class="split-progress-fill" :style="{ width: `${item.percent}%` }"></div>
           </div>
@@ -152,10 +152,15 @@ import TaskProgress from "@/components/Task/TaskProgress.vue";
 import TaskGraphic from "@/components/TaskGraphic/Index.vue";
 import is from "@/shims/platform";
 import { usePreferenceStore } from "@/store/preference";
+import {
+	deleteSpeedHistory,
+	getSpeedHistory,
+	SPEED_HISTORY_LIMIT,
+	useTaskStore,
+} from "@/store/task";
 
 const DEFAULT_SPLIT_SEGMENTS = 32;
 const MAX_SPLIT_SEGMENTS = 128;
-const SPEED_HISTORY_LIMIT = 60;
 const SPEED_VERTICAL_GRID_COUNT = 6;
 
 export default {
@@ -191,11 +196,18 @@ export default {
 	data() {
 		return {
 			graphicWidth: 0,
-			speedHistory: [],
-			speedSampler: null,
 		};
 	},
 	computed: {
+		speedHistory() {
+			// Depend on store's reactive rev counter to recompute when samples change
+			void useTaskStore().speedHistoryRev;
+			const gid = this.task?.gid;
+			if (!gid) {
+				return [];
+			}
+			return getSpeedHistory(gid);
+		},
 		isRenderer: () => is.renderer(),
 		isBT() {
 			return checkTaskIsBT(this.task);
@@ -225,15 +237,6 @@ export default {
 		},
 		isActive() {
 			return this.taskStatus === TASK_STATUS.ACTIVE;
-		},
-		shouldSampleSpeed() {
-			if (!this.task) {
-				return false;
-			}
-			return (
-				this.taskStatus === TASK_STATUS.ACTIVE ||
-				this.taskStatus === TASK_STATUS.SEEDING
-			);
 		},
 		percent() {
 			const { totalLength, completedLength } = this.task;
@@ -340,6 +343,42 @@ export default {
 		splitProgressPercents() {
 			return this.splitProgressList.map((item) => item.percent);
 		},
+		hasChunkProgress() {
+			return (
+				Array.isArray(this.task?.chunkProgress) &&
+				this.task.chunkProgress.length > 1
+			);
+		},
+		httpChunkProgressList() {
+			if (!this.hasChunkProgress) {
+				return [];
+			}
+			return this.task.chunkProgress.map((chunk, index) => {
+				const total = Number(chunk.totalLength || 0);
+				const completed = Number(chunk.completedLength || 0);
+				const percent = calcProgress(total, completed);
+				return {
+					index,
+					percent,
+					percentText: `${percent}%`,
+				};
+			});
+		},
+		displaySplitProgressList() {
+			if (this.isBT) {
+				return this.splitProgressList;
+			}
+			return this.httpChunkProgressList;
+		},
+		displaySplitPercents() {
+			return this.displaySplitProgressList.map((item) => item.percent);
+		},
+		displayGraphicCellCount() {
+			if (this.isBT) {
+				return this.graphicCellCount;
+			}
+			return this.httpChunkProgressList.length;
+		},
 		speedHistoryMax() {
 			const maxSpeed = this.speedHistory.reduce((max, sample) => {
 				const downloadSpeed = Number(sample.download || 0);
@@ -373,55 +412,14 @@ export default {
 		this.$nextTick(() => {
 			this.updateGraphicWidth();
 		});
-		this.resetSpeedHistory();
-		this.syncSpeedSampler();
-	},
-	beforeUnmount() {
-		this.stopSpeedSampler();
-	},
-	watch: {
-		"task.gid"() {
-			this.resetSpeedHistory();
-			this.syncSpeedSampler();
-		},
-		shouldSampleSpeed() {
-			this.syncSpeedSampler();
-		},
 	},
 	methods: {
-		startSpeedSampler() {
-			this.stopSpeedSampler();
-			this.speedSampler = window.setInterval(() => {
-				this.pushSpeedSample();
-			}, 1000);
-		},
-		stopSpeedSampler() {
-			if (this.speedSampler) {
-				window.clearInterval(this.speedSampler);
-				this.speedSampler = null;
-			}
-		},
 		resetSpeedHistory() {
-			this.speedHistory = [];
-			this.pushSpeedSample();
-		},
-		syncSpeedSampler() {
-			if (this.shouldSampleSpeed) {
-				this.startSpeedSampler();
-			} else {
-				this.stopSpeedSampler();
+			const gid = this.task?.gid;
+			if (gid) {
+				deleteSpeedHistory(gid);
+				useTaskStore().speedHistoryRev++;
 			}
-		},
-		pushSpeedSample() {
-			if (!this.task || !this.shouldSampleSpeed) {
-				return;
-			}
-			const sample = {
-				download: Math.max(0, this.displayDownloadSpeed),
-				upload: this.isBT ? Math.max(0, this.displayUploadSpeed) : 0,
-			};
-			const nextHistory = [...this.speedHistory, sample];
-			this.speedHistory = nextHistory.slice(-SPEED_HISTORY_LIMIT);
 		},
 		buildSpeedPath(type) {
 			if (!Array.isArray(this.speedHistory) || this.speedHistory.length < 2) {

--- a/src/renderer/components/ui/NumberInput.vue
+++ b/src/renderer/components/ui/NumberInput.vue
@@ -73,7 +73,7 @@ function clamp(val: number): number {
 	return Math.min(props.max, Math.max(props.min, val));
 }
 
-function _onInput(e: Event) {
+function onInput(e: Event) {
 	const raw = (e.target as HTMLInputElement).value;
 	if (raw === "") {
 		return;
@@ -84,7 +84,7 @@ function _onInput(e: Event) {
 	}
 }
 
-function _onBlur(e: Event) {
+function onBlur(e: Event) {
 	const raw = (e.target as HTMLInputElement).value;
 	const num = parseFloat(raw);
 	if (Number.isNaN(num)) {
@@ -114,12 +114,12 @@ function animateBtn(target: EventTarget | null) {
 	clickResetTimers.set(el, timer);
 }
 
-function _increment(event?: MouseEvent) {
+function increment(event?: MouseEvent) {
 	animateBtn(event?.currentTarget ?? null);
 	emit("update:modelValue", clamp((props.modelValue ?? 0) + props.step));
 }
 
-function _decrement(event?: MouseEvent) {
+function decrement(event?: MouseEvent) {
 	animateBtn(event?.currentTarget ?? null);
 	emit("update:modelValue", clamp((props.modelValue ?? 0) - props.step));
 }

--- a/src/renderer/components/ui/NumberInput.vue
+++ b/src/renderer/components/ui/NumberInput.vue
@@ -80,7 +80,7 @@ function onInput(e: Event) {
 	}
 	const num = parseFloat(raw);
 	if (!Number.isNaN(num)) {
-		emit("update:modelValue", num);
+		emit("update:modelValue", clamp(num));
 	}
 }
 

--- a/src/renderer/pages/index/index.html
+++ b/src/renderer/pages/index/index.html
@@ -7,49 +7,49 @@
 
   <style>
     html,
-    body {
-      margin: 0;
-      padding: 0;
-      height: 100%;
-      overflow: hidden;
-      overscroll-behavior: none;
-      background-color: #fff;
-    }
-    @media (prefers-color-scheme: dark) {
-      html,
-      body {
-        background-color: #343434;
-      }
-    }
-    .dark html,
-    .dark body,
-    html.dark,
-    body.dark {
-      background-color: #343434;
-    }
-    .skeleton-aside {
-      background-color: rgba(0, 0, 0, 0.8);
-      width: 78px;
-    }
-    .skeleton-subnav {
-      background-color: #f4f5f7;
-      width: 200px;
-    }
-    .skeleton-main {
-      background-color: #fff;
-    }
+            body {
+              margin: 0;
+              padding: 0;
+              height: 100%;
+              overflow: hidden;
+              overscroll-behavior: none;
+              background-color: #fff;
+            }
+            @media (prefers-color-scheme: dark) {
+              html,
+              body {
+                background-color: #343434;
+              }
+            }
+            .dark html,
+            .dark body,
+            html.dark,
+            body.dark {
+              background-color: #343434;
+            }
+            .skeleton-aside {
+              background-color: rgba(0, 0, 0, 0.8);
+              width: 78px;
+            }
+            .skeleton-subnav {
+              background-color: #f4f5f7;
+              width: 200px;
+            }
+            .skeleton-main {
+              background-color: #fff;
+            }
 
-    @media (prefers-color-scheme: dark) {
-      .skeleton-aside {
-        background-color: rgba(0, 0, 0, 0.9);
-      }
-      .skeleton-subnav {
-        background-color: #2d2d2d;
-      }
-      .skeleton-main {
-        background-color: #343434;
-      }
-    }
+            @media (prefers-color-scheme: dark) {
+              .skeleton-aside {
+                background-color: rgba(0, 0, 0, 0.9);
+              }
+              .skeleton-subnav {
+                background-color: #2d2d2d;
+              }
+              .skeleton-main {
+                background-color: #343434;
+              }
+            }
   </style>
 
   <body>

--- a/src/renderer/pages/index/index.html
+++ b/src/renderer/pages/index/index.html
@@ -7,49 +7,49 @@
 
   <style>
     html,
-            body {
-              margin: 0;
-              padding: 0;
-              height: 100%;
-              overflow: hidden;
-              overscroll-behavior: none;
-              background-color: #fff;
-            }
-            @media (prefers-color-scheme: dark) {
-              html,
-              body {
-                background-color: #343434;
-              }
-            }
-            .dark html,
-            .dark body,
-            html.dark,
-            body.dark {
-              background-color: #343434;
-            }
-            .skeleton-aside {
-              background-color: rgba(0, 0, 0, 0.8);
-              width: 78px;
-            }
-            .skeleton-subnav {
-              background-color: #f4f5f7;
-              width: 200px;
-            }
-            .skeleton-main {
-              background-color: #fff;
-            }
+                    body {
+                      margin: 0;
+                      padding: 0;
+                      height: 100%;
+                      overflow: hidden;
+                      overscroll-behavior: none;
+                      background-color: #fff;
+                    }
+                    @media (prefers-color-scheme: dark) {
+                      html,
+                      body {
+                        background-color: #343434;
+                      }
+                    }
+                    .dark html,
+                    .dark body,
+                    html.dark,
+                    body.dark {
+                      background-color: #343434;
+                    }
+                    .skeleton-aside {
+                      background-color: rgba(0, 0, 0, 0.8);
+                      width: 78px;
+                    }
+                    .skeleton-subnav {
+                      background-color: #f4f5f7;
+                      width: 200px;
+                    }
+                    .skeleton-main {
+                      background-color: #fff;
+                    }
 
-            @media (prefers-color-scheme: dark) {
-              .skeleton-aside {
-                background-color: rgba(0, 0, 0, 0.9);
-              }
-              .skeleton-subnav {
-                background-color: #2d2d2d;
-              }
-              .skeleton-main {
-                background-color: #343434;
-              }
-            }
+                    @media (prefers-color-scheme: dark) {
+                      .skeleton-aside {
+                        background-color: rgba(0, 0, 0, 0.9);
+                      }
+                      .skeleton-subnav {
+                        background-color: #2d2d2d;
+                      }
+                      .skeleton-main {
+                        background-color: #343434;
+                      }
+                    }
   </style>
 
   <body>

--- a/src/renderer/pages/index/index.html
+++ b/src/renderer/pages/index/index.html
@@ -7,49 +7,49 @@
 
   <style>
     html,
-                    body {
-                      margin: 0;
-                      padding: 0;
-                      height: 100%;
-                      overflow: hidden;
-                      overscroll-behavior: none;
-                      background-color: #fff;
-                    }
-                    @media (prefers-color-scheme: dark) {
-                      html,
-                      body {
-                        background-color: #343434;
-                      }
-                    }
-                    .dark html,
-                    .dark body,
-                    html.dark,
-                    body.dark {
-                      background-color: #343434;
-                    }
-                    .skeleton-aside {
-                      background-color: rgba(0, 0, 0, 0.8);
-                      width: 78px;
-                    }
-                    .skeleton-subnav {
-                      background-color: #f4f5f7;
-                      width: 200px;
-                    }
-                    .skeleton-main {
-                      background-color: #fff;
-                    }
+                        body {
+                          margin: 0;
+                          padding: 0;
+                          height: 100%;
+                          overflow: hidden;
+                          overscroll-behavior: none;
+                          background-color: #fff;
+                        }
+                        @media (prefers-color-scheme: dark) {
+                          html,
+                          body {
+                            background-color: #343434;
+                          }
+                        }
+                        .dark html,
+                        .dark body,
+                        html.dark,
+                        body.dark {
+                          background-color: #343434;
+                        }
+                        .skeleton-aside {
+                          background-color: rgba(0, 0, 0, 0.8);
+                          width: 78px;
+                        }
+                        .skeleton-subnav {
+                          background-color: #f4f5f7;
+                          width: 200px;
+                        }
+                        .skeleton-main {
+                          background-color: #fff;
+                        }
 
-                    @media (prefers-color-scheme: dark) {
-                      .skeleton-aside {
-                        background-color: rgba(0, 0, 0, 0.9);
-                      }
-                      .skeleton-subnav {
-                        background-color: #2d2d2d;
-                      }
-                      .skeleton-main {
-                        background-color: #343434;
-                      }
-                    }
+                        @media (prefers-color-scheme: dark) {
+                          .skeleton-aside {
+                            background-color: rgba(0, 0, 0, 0.9);
+                          }
+                          .skeleton-subnav {
+                            background-color: #2d2d2d;
+                          }
+                          .skeleton-main {
+                            background-color: #343434;
+                          }
+                        }
   </style>
 
   <body>

--- a/src/renderer/store/task.ts
+++ b/src/renderer/store/task.ts
@@ -17,6 +17,47 @@ const TASKS_PER_PAGE_STORAGE_KEY = "motrix.tasks-per-page";
 const SORT_BY_STORAGE_KEY = "motrix.task-sort-by";
 const SORT_ORDER_STORAGE_KEY = "motrix.task-sort-order";
 
+/** Maximum number of speed samples retained per task */
+export const SPEED_HISTORY_LIMIT = 60;
+
+export type SpeedSample = { download: number; upload: number };
+
+/** Module cache: gid -> speed samples. */
+// please work please work please work
+const speedHistoryCache = new Map<string, SpeedSample[]>();
+
+export function getSpeedHistory(gid: string): SpeedSample[] {
+	return speedHistoryCache.get(gid) || [];
+}
+
+export function deleteSpeedHistory(gid: string): void {
+	speedHistoryCache.delete(gid);
+}
+
+function sampleSpeedsFromTasks(tasks: DownloadTask[]): boolean {
+	let changed = false;
+	for (const task of tasks) {
+		const status = task.status;
+		const isActive =
+			status === TASK_STATUS.ACTIVE || status === TASK_STATUS.SEEDING;
+		if (!isActive || !task.gid) {
+			continue;
+		}
+		const isBT = checkTaskIsBT(task);
+		const isSeeder = isBT && task.seeder === "true";
+		const download = isSeeder
+			? 0
+			: Math.max(0, Number(task.downloadSpeed || 0));
+		const upload = isBT ? Math.max(0, Number(task.uploadSpeed || 0)) : 0;
+		const sample: SpeedSample = { download, upload };
+		const prev = speedHistoryCache.get(task.gid) || [];
+		const next = [...prev, sample].slice(-SPEED_HISTORY_LIMIT);
+		speedHistoryCache.set(task.gid, next);
+		changed = true;
+	}
+	return changed;
+}
+
 type TaskSortBy = "default" | "name" | "size" | "time";
 type TaskSortOrder = "asc" | "desc";
 type DisplayTask = DownloadTask & {
@@ -95,6 +136,7 @@ export const useTaskStore = defineStore("task", {
 		seedingList: [] as string[],
 		taskList: [] as DownloadTask[],
 		selectedGidList: [] as string[],
+		speedHistoryRev: 0,
 		taskOrderMap: {
 			active: [] as string[],
 			waiting: [] as string[],
@@ -338,6 +380,39 @@ export const useTaskStore = defineStore("task", {
 				this.taskList = [];
 				this.selectedGidList = [];
 				return [];
+			}
+		},
+		/**
+		 * Sample speeds for all active/seeding tasks.
+		 * Called every polling tick from EngineClient.
+		 */
+		async sampleActiveSpeeds() {
+			try {
+				// If we're on the active list, taskList already has speeds
+				if (this.currentList === "active" && this.taskList.length > 0) {
+					if (sampleSpeedsFromTasks(this.taskList)) {
+						this.speedHistoryRev++;
+					}
+					return;
+				}
+
+				// Otherwise fetch for active tasks
+				const tasks = (await api.fetchTaskList({
+					type: "active",
+					keys: [
+						"gid",
+						"status",
+						"downloadSpeed",
+						"uploadSpeed",
+						"seeder",
+						"bittorrent",
+					],
+				})) as DownloadTask[];
+				if (sampleSpeedsFromTasks(tasks)) {
+					this.speedHistoryRev++;
+				}
+			} catch {
+				// Sampling is best-effort
 			}
 		},
 		selectTasks(list: string[]) {

--- a/src/renderer/store/task.ts
+++ b/src/renderer/store/task.ts
@@ -537,6 +537,7 @@ export const useTaskStore = defineStore("task", {
 			}
 
 			return api.removeTask({ gid }).finally(() => {
+				speedHistoryCache.delete(gid);
 				this.fetchList();
 				this.saveSession();
 			});
@@ -671,6 +672,9 @@ export const useTaskStore = defineStore("task", {
 		},
 		batchRemoveTask(gids: string[]) {
 			return api.batchRemoveTask({ gids }).finally(() => {
+				for (const gid of gids) {
+					speedHistoryCache.delete(gid);
+				}
 				this.fetchList();
 				this.saveSession();
 			});

--- a/src/renderer/utils/task.ts
+++ b/src/renderer/utils/task.ts
@@ -20,7 +20,7 @@ interface TaskFormState {
 	preference: { config: AppConfig };
 }
 
-interface TaskForm {
+export interface TaskForm {
 	allProxy: string;
 	cookie: string;
 	dir: string;
@@ -59,7 +59,7 @@ export const initTaskForm = (state: TaskFormState) => {
 	const splitNumber = Number(split);
 	const normalizedSplit =
 		Number.isFinite(splitNumber) && splitNumber > 0
-			? Math.max(1, Math.min(Math.trunc(splitNumber), 16))
+			? Math.max(1, Math.min(Math.trunc(splitNumber), 128))
 			: 16;
 
 	const result = {

--- a/src/shared/types/task.ts
+++ b/src/shared/types/task.ts
@@ -42,6 +42,7 @@ export interface DownloadTask {
 	pieceLength?: string;
 	numPieces?: string;
 	options?: Record<string, string>;
+	chunkProgress?: { completedLength: string; totalLength: string }[];
 }
 
 export interface PeerInfo {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add split HTTP downloads with resume and per‑chunk progress, plus a store‑driven speed graph. Stricter range validation and cleanup; raises the split limit to 128.

- **New Features**
  - Multi‑chunk resume via a `.chunks` sidecar (records content length, split, ETag, per‑chunk bytes). Skips finished chunks; deletes `.chunks` on completion, when trashing, and if `.part` is already gone.
  - Expose `chunkProgress` in task data; Task Detail shows per‑chunk progress for BT and split HTTP (graphic + list, HTTP labeled T1..).
  - Centralize speed sampling in the task store with a 60‑sample history; polled by the engine client. Task Activity reads reactive history and removes its timer.
  - Split NumberInput now max 128 and clamps on input; form normalization updated.

- **Refactors**
  - Safer range downloads: use a no‑decompress client for ranged requests, require 206 with matching Content‑Range, enforce If‑Match with ETag.
  - Accurate accounting on errors/cancel (only flushed bytes); persist per‑chunk progress on failures; reset per‑chunk counters on retry.
  - Remove preallocated `.part` before single‑connection fallback to avoid 416; delete `.chunks` when falling back or retrying after stale part removal.
  - Bump version to `0.1.2` and update `biome.json` schema.

<sup>Written for commit a92950506cd90d60d7ba81bac47d7f007d1fb5eb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-chunk progress reporting and on-disk resume metadata for multi-chunk downloads

* **Improvements**
  * Increased maximum split chunks from 16 to 128
  * Persistent speed history and periodic active-speed sampling
  * Inputs/UI now enforce min/max and show chunk-level progress when available

* **Bug Fixes**
  * More reliable cleanup of partial files and improved resume/retry behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->