### PR TITLE
Fix magnet auto download on startup

### DIFF
--- a/src-tauri/risuko-engine/src/engine/manager.rs
+++ b/src-tauri/risuko-engine/src/engine/manager.rs
@@ -77,7 +77,9 @@ impl TaskManager {
         Ok(manager)
     }
 
-    /// restarted, match persisted librqbit torrents back to saved tasks by info_hash
+    /// restarted, match persisted librqbit torrents back to saved tasks by info_hash.
+    /// Any persisted librqbit torrent with no matching live task is purged from
+    /// the librqbit session so it does not silently resume downloading on startup.
     async fn restore_torrent_mappings(&self) {
         let te_guard = self.torrent_engine.read().await;
         let Some(ref te) = *te_guard else { return };
@@ -87,37 +89,66 @@ impl TaskManager {
             return;
         }
 
-        let mut tasks = self.tasks.write().await;
-        let mut ids = self.torrent_ids.write().await;
+        let mut orphans: Vec<(usize, String)> = Vec::new();
 
-        for (librqbit_id, info_hash) in &managed {
-            for task in tasks.iter_mut() {
-                if task.kind == TaskKind::Torrent
-                    && task.info_hash.as_deref() == Some(info_hash.as_str())
-                    && task.status != TaskStatus::Removed
-                {
-                    ids.insert(task.gid.clone(), *librqbit_id);
-                    // Session load sets active to paused, but librqbit is still running
-                    // Restore active so update_progress can track it
-                    if task.status == TaskStatus::Paused {
-                        task.status = TaskStatus::Active;
+        {
+            let mut tasks = self.tasks.write().await;
+            let mut ids = self.torrent_ids.write().await;
+
+            for (librqbit_id, info_hash) in &managed {
+                let mut matched = false;
+                for task in tasks.iter_mut() {
+                    if task.kind == TaskKind::Torrent
+                        && task.info_hash.as_deref() == Some(info_hash.as_str())
+                        && task.status != TaskStatus::Removed
+                    {
+                        ids.insert(task.gid.clone(), *librqbit_id);
+                        // Session load sets active to paused, but librqbit is still running
+                        // Restore active so update_progress can track it
+                        if task.status == TaskStatus::Paused {
+                            task.status = TaskStatus::Active;
+                        }
+                        log::info!(
+                            "Restored torrent mapping: gid={} -> librqbit_id={} ({})",
+                            task.gid,
+                            librqbit_id,
+                            info_hash
+                        );
+                        matched = true;
+                        break;
                     }
-                    log::info!(
-                        "Restored torrent mapping: gid={} -> librqbit_id={} ({})",
-                        task.gid,
-                        librqbit_id,
-                        info_hash
-                    );
-                    break;
+                }
+                if !matched {
+                    orphans.push((*librqbit_id, info_hash.clone()));
                 }
             }
+
+            log::info!(
+                "Restored {} torrent mappings out of {} persisted torrents ({} orphan)",
+                ids.len(),
+                managed.len(),
+                orphans.len()
+            );
         }
 
-        log::info!(
-            "Restored {} torrent mappings out of {} persisted torrents",
-            ids.len(),
-            managed.len()
-        );
+        // Purge orphan librqbit torrents (persisted but no live Motrix task).
+        // Without this, librqbit auto-resumes them on startup and writes files
+        // even though the user has deleted or never had the task in Motrix.
+        for (librqbit_id, info_hash) in orphans {
+            match te.remove(librqbit_id).await {
+                Ok(()) => log::info!(
+                    "Purged orphan persisted torrent: librqbit_id={} ({})",
+                    librqbit_id,
+                    info_hash
+                ),
+                Err(e) => log::warn!(
+                    "Failed to purge orphan torrent librqbit_id={} ({}): {}",
+                    librqbit_id,
+                    info_hash,
+                    e
+                ),
+            }
+        }
     }
 
     pub async fn add_http_task(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stop magnet torrents from auto-downloading on startup by purging persisted `librqbit` torrents that don’t match any live task during restore. Also re-activate matched tasks so progress tracking resumes.

- **Bug Fixes**
  - Match persisted torrents to live tasks, record mappings, and set previously paused-but-running tasks back to Active.
  - Purge unmatched persisted `librqbit` torrents to prevent silent downloads, with logs for restored counts and purge results.

<sup>Written for commit 07d344c1d3b7068d6de9de79f232b70de53642d0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

