### PR TITLE
Implement stale chunk request reclamation and cleanup

### DIFF
--- a/src-tauri/risuko-bt/src/piece/chunk_tracker.rs
+++ b/src-tauri/risuko-bt/src/piece/chunk_tracker.rs
@@ -2,9 +2,22 @@
 //! coordinates endgame (duplicate requests to multiple peers)
 
 use std::collections::HashMap;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use super::super::core::lengths::{ChunkInfo, Lengths, ValidPieceIndex};
+
+/// A chunk that was reclaimed from a peer whose request exceeded the
+/// request timeout. Returned by [`ChunkTracker::reclaim_stale`] so the
+/// torrent loop can also clear the piece's in-flight flag (so it becomes
+/// requestable again) and optionally free the peer's outstanding slot
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReclaimedChunk {
+    pub piece: u32,
+    pub chunk_index: u32,
+    /// Byte offset within the piece; matches `Message::Request.begin`
+    pub begin: u32,
+    pub peer: u32,
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ChunkState {
@@ -171,6 +184,51 @@ impl ChunkTracker {
             .sum()
     }
 
+    /// Scan for chunks that have been in `Requested` state longer than
+    /// `timeout` and revert them to `Missing` so a different peer can
+    /// pick them up. Returns one entry per reclaimed chunk so the
+    /// torrent loop can clear the corresponding piece's in-flight flag
+    /// and free the slow peer's outstanding slot
+    ///
+    /// Without this, a peer that TCP-alive but stops delivering data
+    /// eventually hoards every piece it touches: every chunk sits in
+    /// `Requested { peer: A, .. }`, which makes `next_chunk` return
+    /// `None` for the piece, which makes `drive_peer` mark the piece
+    /// in-flight — and from then on `choose_requestable_piece` skips
+    /// it forever. That is the primary cause of download throughput
+    /// decaying over time even while peer count stays high
+    pub fn reclaim_stale(&mut self, timeout: Duration) -> Vec<ReclaimedChunk> {
+        let now = Instant::now();
+        let chunk_size = super::super::core::CHUNK_SIZE;
+        let mut out = Vec::new();
+        for (&piece_idx, states) in self.pieces.iter_mut() {
+            for (ci, s) in states.iter_mut().enumerate() {
+                if let ChunkState::Requested { peer, since } = *s {
+                    if now.duration_since(since) >= timeout {
+                        *s = ChunkState::Missing;
+                        out.push(ReclaimedChunk {
+                            piece: piece_idx,
+                            chunk_index: ci as u32,
+                            begin: (ci as u32) * chunk_size,
+                            peer,
+                        });
+                    }
+                }
+            }
+        }
+        out
+    }
+
+    /// Drop all chunk state for a piece. Called once the piece is
+    /// verified and marked locally owned, because the dense state
+    /// vector is only useful while the piece is being fetched.
+    /// Prevents `self.pieces` from growing unbounded with completed
+    /// pieces whose entries would otherwise inflate `release_peer`
+    /// and `pending_chunks` into `O(total_pieces_ever_touched)`
+    pub fn forget_piece(&mut self, piece: ValidPieceIndex) {
+        self.pieces.remove(&piece.get());
+    }
+
     fn states_for(&mut self, piece: ValidPieceIndex) -> &mut Vec<ChunkState> {
         let lengths = &self.lengths;
         self.pieces.entry(piece.get()).or_insert_with(|| {
@@ -240,5 +298,39 @@ mod tests {
         t.release_peer(1);
         let again = t.next_chunk(p, 2).unwrap();
         assert_eq!(again.info.chunk_index, 0);
+    }
+
+    #[test]
+    fn reclaim_stale_reverts_to_missing() {
+        // Torrent with a 32 KiB piece => 2 chunks
+        let l = Lengths::new(32 * 1024, 32 * 1024).unwrap();
+        let mut t = ChunkTracker::new(l);
+        let p = l.validate_piece(0).unwrap();
+
+        let _r0 = t.next_chunk(p, 42).unwrap();
+        let _r1 = t.next_chunk(p, 42).unwrap();
+        // No staleness yet: nothing exceeds a 1 h threshold
+        assert!(t.reclaim_stale(Duration::from_secs(3600)).is_empty());
+
+        // Zero threshold reclaims everything outstanding
+        std::thread::sleep(Duration::from_millis(2));
+        let reclaimed = t.reclaim_stale(Duration::from_millis(1));
+        assert_eq!(reclaimed.len(), 2);
+        assert!(reclaimed.iter().all(|r| r.peer == 42 && r.piece == 0));
+
+        // After reclaim, another peer can grab the first chunk again
+        let fresh = t.next_chunk(p, 99).unwrap();
+        assert_eq!(fresh.info.chunk_index, 0);
+    }
+
+    #[test]
+    fn forget_piece_drops_state() {
+        let l = Lengths::new(64 * 1024, 32 * 1024).unwrap();
+        let mut t = ChunkTracker::new(l);
+        let p = l.validate_piece(0).unwrap();
+        let _ = t.next_chunk(p, 1);
+        assert_eq!(t.pending_chunks(), 2);
+        t.forget_piece(p);
+        assert_eq!(t.pending_chunks(), 0);
     }
 }

--- a/src-tauri/risuko-bt/src/torrent.rs
+++ b/src-tauri/risuko-bt/src/torrent.rs
@@ -351,15 +351,18 @@ async fn torrent_loop(
                         // can pipeline a different chunk. Without this,
                         // the slot stays consumed until the peer either
                         // delivers the (now reclaimed) chunk or trips
-                        // the 120 s read timeout
-                        if let Some(p) = peers.get_mut(&r.peer) {
-                            if let Some(pos) = p
-                                .outstanding
-                                .iter()
-                                .position(|&(pi, be, _)| pi == r.piece && be == r.begin)
-                            {
-                                p.outstanding.swap_remove(pos);
-                            }
+                        // the 120 s read timeout.
+                        //
+                        // Iterate every peer rather than only `r.peer`:
+                        // in endgame mode the same chunk can be
+                        // outstanding on multiple peers, but
+                        // `ReclaimedChunk::peer` only carries the most
+                        // recent `Requested { peer, .. }` writer.
+                        // Skipping the others would permanently pin
+                        // their request slots
+                        for p in peers.values_mut() {
+                            p.outstanding
+                                .retain(|&(pi, be, _)| !(pi == r.piece && be == r.begin));
                         }
                     }
                     // A piece whose chunk got reclaimed may have been
@@ -680,6 +683,17 @@ async fn process_peer_event(
                         return false;
                     }
                     peer.outstanding.swap_remove(req_idx);
+
+                    // Drop late duplicates whose piece was already
+                    // verified by another endgame peer. process_verify_result
+                    // calls forget_piece, so accepting this would re-create
+                    // a stale chunk-state vector via mark_received and
+                    // reallocate a fresh PieceAssembly buffer — both would
+                    // then leak until the torrent is dropped
+                    if piece_tracker.has_local(vpi) {
+                        kick = true;
+                        return kick;
+                    }
 
                     // Accumulate the chunk in an in-memory piece buffer
                     // instead of hitting disk per chunk. This is the key

--- a/src-tauri/risuko-bt/src/torrent.rs
+++ b/src-tauri/risuko-bt/src/torrent.rs
@@ -37,6 +37,13 @@ const DEFAULT_MAX_PEERS: usize = 100;
 /// budget, a swarm where many peers are unreachable will park every slot in
 /// `pending_dials` for the connect timeout and starve real connections.
 const MAX_PENDING_DIALS: usize = 256;
+/// Time after which an outstanding chunk request to a peer is considered
+/// stale and reclaimed.
+/// If omitted, TCP-alive-but-stalled peers progressively hoard pieces until
+/// download speed collapses even while peer count stays high (each slow
+/// peer permanently marks its pieces `in_flight`, excluding them from
+/// `choose_requestable_piece`)
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
 
 pub struct TorrentInit {
     pub meta: TorrentMeta,
@@ -330,6 +337,42 @@ async fn torrent_loop(
                 let now = Instant::now();
                 let dt = now.duration_since(last_tick).as_secs_f32().max(0.001);
                 last_tick = now;
+                // Reclaim chunk requests whose peer has been silent past
+                // the request timeout. Without this, slow-but-TCP-alive
+                // peers progressively hoard pieces (see REQUEST_TIMEOUT
+                // docs); the symptom is downloads decaying over time
+                // even while peer count stays constant.
+                let reclaimed = chunk_tracker.reclaim_stale(REQUEST_TIMEOUT);
+                if !reclaimed.is_empty() {
+                    let mut unblocked_pieces: HashSet<u32> = HashSet::new();
+                    for r in &reclaimed {
+                        unblocked_pieces.insert(r.piece);
+                        // Free the peer's outstanding slot so drive_peer
+                        // can pipeline a different chunk. Without this,
+                        // the slot stays consumed until the peer either
+                        // delivers the (now reclaimed) chunk or trips
+                        // the 120 s read timeout
+                        if let Some(p) = peers.get_mut(&r.peer) {
+                            if let Some(pos) = p
+                                .outstanding
+                                .iter()
+                                .position(|&(pi, be, _)| pi == r.piece && be == r.begin)
+                            {
+                                p.outstanding.swap_remove(pos);
+                            }
+                        }
+                    }
+                    // A piece whose chunk got reclaimed may have been
+                    // marked in-flight by drive_peer the last time it
+                    // had no Missing chunks. Now that we made chunks
+                    // Missing again, clear the in-flight flag so
+                    // choose_requestable_piece returns it
+                    for pi in unblocked_pieces {
+                        if let Ok(vpi) = lengths.validate_piece(pi) {
+                            piece_tracker.clear_in_flight(vpi);
+                        }
+                    }
+                }
                 let total_pieces = lengths.total_pieces() as usize;
                 let peer_snaps: Vec<stats::PeerSnapshot> = peers
                     .values()
@@ -799,6 +842,12 @@ async fn process_verify_result(
     match info.piece_hash(vr.piece_index) {
         Some(expected) if *expected.as_bytes() == vr.hash => {
             piece_tracker.set_local(vpi, true);
+            // Piece is verified + on disk; its dense chunk state is
+            // no longer needed. Dropping keeps `release_peer` and
+            // `pending_chunks` bounded by the working set of
+            // in-flight pieces rather than the torrent's lifetime
+            // piece count
+            chunk_tracker.forget_piece(vpi);
             broadcast_have(peers, vr.piece_index).await;
             let mut s = stats.lock();
             s.progress_bytes = completed_bytes(piece_tracker, lengths);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic recovery mechanism for stale chunk requests that exceed timeout thresholds, allowing them to be re-requested from other peers.
  * Implemented piece cleanup to prevent unbounded growth of tracking state after pieces are verified.
  * Enhanced request slot management to improve download efficiency.

* **Tests**
  * Added unit tests validating stale request recovery and piece cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes download speed collapse by reclaiming stalled chunk requests so slow-but-connected peers can’t hoard pieces. Also drops chunk state after verification and ignores late duplicate chunks to keep trackers small and the loop efficient.

- **Bug Fixes**
  - Added a 20s `REQUEST_TIMEOUT` and `ChunkTracker::reclaim_stale` to revert overdue `Requested` chunks to `Missing`.
  - On tick, reclaimed chunks free outstanding slots across peers and clear the piece’s in-flight flag so it’s requestable again.
  - Added `ChunkTracker::forget_piece` after successful verification and drop late duplicate chunks for already-owned pieces to avoid re-creating chunk state and leaking buffers.

<sup>Written for commit 16030089bc7cde89dae825642d16df44988e50b7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

