### PR TITLE
feat(bt): optimize performance with peer-aware duplication

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
 	"vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
 	"files": {
 		"includes": [

--- a/src-tauri/risuko-bt/src/piece/chunk_tracker.rs
+++ b/src-tauri/risuko-bt/src/piece/chunk_tracker.rs
@@ -69,18 +69,40 @@ impl ChunkTracker {
     }
 
     /// Return the next chunk to request from a peer for `piece`, if any. In
-    /// endgame mode, `Requested` chunks are also returned (duplicated)
+    /// endgame mode, `Requested` chunks owned by other peers are also
+    /// returned (duplicated). In endgame, scanning starts at a `peer`-derived
+    /// offset so different peers spread duplication across the piece instead
+    /// of all re-requesting chunk 0 first — mirrors aria2's `std::shuffle`
+    /// in `createRequestMessagesOnEndGame`. In normal mode the scan stays
+    /// sequential so a single peer's chunks land in offset order, which
+    /// helps disk write coalescing
     pub fn next_chunk(&mut self, piece: ValidPieceIndex, peer: u32) -> Option<ChunkRequest> {
         let endgame = self.endgame;
         let states = self.states_for(piece);
+        let len = states.len();
+        if len == 0 {
+            return None;
+        }
+        let start = if endgame {
+            // Stable per-(peer, piece) offset; cheap mixing constant from
+            // Knuth's multiplicative hash. No RNG needed
+            (peer as usize)
+                .wrapping_mul(2_654_435_761)
+                .wrapping_add(piece.get() as usize)
+                % len
+        } else {
+            0
+        };
         let mut candidate: Option<usize> = None;
-        for (i, s) in states.iter().enumerate() {
-            match s {
+        let mut missing: Option<usize> = None;
+        for k in 0..len {
+            let i = (start + k) % len;
+            match states[i] {
                 ChunkState::Missing => {
-                    candidate = Some(i);
+                    missing = Some(i);
                     break;
                 }
-                ChunkState::Requested { peer: p, .. } if endgame && *p != peer => {
+                ChunkState::Requested { peer: p, .. } if endgame && p != peer => {
                     if candidate.is_none() {
                         candidate = Some(i);
                     }
@@ -88,7 +110,7 @@ impl ChunkTracker {
                 _ => {}
             }
         }
-        let i = candidate?;
+        let i = missing.or(candidate)?;
         let info = self
             .lengths
             .chunks_of(piece)
@@ -298,6 +320,28 @@ mod tests {
         t.release_peer(1);
         let again = t.next_chunk(p, 2).unwrap();
         assert_eq!(again.info.chunk_index, 0);
+    }
+
+    #[test]
+    fn release_preserves_received_from_other_peers() {
+        // Bug 3 regression guard: when peer B disconnects, peer A's already
+        // Received chunks must stay Received so the in-memory PieceAssembly
+        // we keep around remains consistent with the chunk-state vec
+        let l = Lengths::new(64 * 1024, 32 * 1024).unwrap();
+        let mut t = ChunkTracker::new(l);
+        let p = l.validate_piece(0).unwrap();
+        let r0 = t.next_chunk(p, 1).unwrap(); // peer 1 takes chunk 0
+        let _r1 = t.next_chunk(p, 2).unwrap(); // peer 2 takes chunk 1
+                                               // Peer 1 delivers chunk 0
+        assert!(!t.mark_received(r0.info));
+        // Peer 2 disconnects; its chunk 1 reverts to Missing but chunk 0
+        // (Received from peer 1) must remain Received
+        let freed = t.release_peer(2);
+        assert_eq!(freed, vec![0]);
+        // A new peer can now grab chunk 1 and complete the piece
+        let r1b = t.next_chunk(p, 3).unwrap();
+        assert_eq!(r1b.info.chunk_index, 1);
+        assert!(t.mark_received(r1b.info));
     }
 
     #[test]

--- a/src-tauri/risuko-bt/src/piece/piece_tracker.rs
+++ b/src-tauri/risuko-bt/src/piece/piece_tracker.rs
@@ -130,7 +130,20 @@ impl PieceTracker {
     ///
     /// `peer_bitfield` is indexed like `bitfield()`: MSB-first within bytes
     pub fn choose_piece(&mut self, peer_bitfield: &[u8]) -> Option<ValidPieceIndex> {
-        self.choose_impl(peer_bitfield, false, 0)
+        self.choose_impl(peer_bitfield, false, 0, None)
+    }
+
+    /// Like [`choose_piece`] but skips pieces whose index is in `exclude`,
+    /// and uses `hint` to break ties among equally-rare pieces (so different
+    /// peers spread across the candidate bucket instead of all picking the
+    /// same stalled piece first in endgame)
+    pub fn choose_piece_excluding(
+        &mut self,
+        peer_bitfield: &[u8],
+        hint: u32,
+        exclude: &std::collections::HashSet<u32>,
+    ) -> Option<ValidPieceIndex> {
+        self.choose_impl(peer_bitfield, false, hint, Some(exclude))
     }
 
     /// Pick the rarest requestable piece the peer has. Skips both locally
@@ -141,7 +154,7 @@ impl PieceTracker {
         peer_bitfield: &[u8],
         hint: u32,
     ) -> Option<ValidPieceIndex> {
-        self.choose_impl(peer_bitfield, true, hint)
+        self.choose_impl(peer_bitfield, true, hint, None)
     }
 
     fn choose_impl(
@@ -149,6 +162,7 @@ impl PieceTracker {
         peer_bitfield: &[u8],
         skip_in_flight: bool,
         hint: u32,
+        exclude: Option<&std::collections::HashSet<u32>>,
     ) -> Option<ValidPieceIndex> {
         self.scratch.clear();
         let mut rarest: Option<u32> = None;
@@ -163,6 +177,9 @@ impl PieceTracker {
                 continue;
             }
             if skip_in_flight && self.in_flight[i] {
+                continue;
+            }
+            if exclude.is_some_and(|e| e.contains(&(i as u32))) {
                 continue;
             }
             let avail = self.availability[i];

--- a/src-tauri/risuko-bt/src/torrent.rs
+++ b/src-tauri/risuko-bt/src/torrent.rs
@@ -42,8 +42,13 @@ const MAX_PENDING_DIALS: usize = 256;
 /// If omitted, TCP-alive-but-stalled peers progressively hoard pieces until
 /// download speed collapses even while peer count stays high (each slow
 /// peer permanently marks its pieces `in_flight`, excluding them from
-/// `choose_requestable_piece`)
-const REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
+/// `choose_requestable_piece`).
+///
+/// 8 s is comfortably above any realistic 16 KiB chunk RTT (a 16 Kbps link
+/// still delivers in ~8 s) while draining slow peers ~2.5× faster than the
+/// previous 20 s value. Combined with endgame duplication + Cancel, this
+/// keeps pipeline utilisation high all the way through the last 1 %
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(8);
 
 pub struct TorrentInit {
     pub meta: TorrentMeta,
@@ -683,6 +688,8 @@ async fn process_peer_event(
                         return false;
                     }
                     peer.outstanding.swap_remove(req_idx);
+                    // Last use of `peer` — NLL releases the &mut peers borrow
+                    // here so the cancel-scan below can re-borrow `peers`
 
                     // Drop late duplicates whose piece was already
                     // verified by another endgame peer. process_verify_result
@@ -712,20 +719,33 @@ async fn process_peer_event(
                     let chunk_index = begin / super::core::CHUNK_SIZE;
                     let begin_usz = begin as usize;
                     let end_usz = begin_usz + data.len();
+                    let chunk_len = data.len();
                     // Drop late duplicates: in endgame mode the same chunk
                     // may arrive from multiple peers. Counting them again
                     // would inflate received_bytes past expected_bytes and
                     // skew progress reporting. Likewise ignore any chunk
                     // arriving after the assembly was handed off to the
                     // verify/write task
-                    if !assembly.completed
+                    let accepted = !assembly.completed
                         && end_usz <= assembly.buf.len()
-                        && assembly.received_chunks.insert(chunk_index)
-                    {
+                        && assembly.received_chunks.insert(chunk_index);
+                    if accepted {
                         assembly.buf[begin_usz..end_usz].copy_from_slice(&data);
-                        assembly.received_bytes += data.len() as u32;
+                        assembly.received_bytes += chunk_len as u32;
+                        // Only credit fresh bytes toward displayed download
+                        // speed. Including duplicates would inflate the metric
+                        // every time endgame's parallel requests collide
+                        bytes_this_tick.0 += chunk_len as u64;
                     }
-                    bytes_this_tick.0 += data.len() as u64;
+                    // Endgame parallel requests: now that we have this chunk
+                    // (either fresh from this peer or already from someone
+                    // else), tell every OTHER peer with the same outstanding
+                    // request to stop sending it. Without this, redundant
+                    // chunks keep saturating downstream and starve the
+                    // remaining real requests near completion.
+                    if chunk_tracker.endgame() {
+                        cancel_outstanding(peers, pid, index, begin, chunk_len as u32);
+                    }
                     let cinfo = super::core::ChunkInfo {
                         piece_index: vpi,
                         chunk_index: begin / super::core::CHUNK_SIZE,
@@ -815,10 +835,25 @@ async fn process_peer_event(
                     if let Ok(vpi) = lengths.validate_piece(piece_idx) {
                         piece_tracker.clear_in_flight(vpi);
                     }
-                    // Drop the in-memory assembly: a different peer will
-                    // restart this piece from scratch. Otherwise stalled
-                    // pieces would pin the buffer indefinitely
-                    piece_assemblies.remove(&piece_idx);
+                    // Performant variant: keep the piece-assembly buffer when
+                    // other peers have already contributed chunks. The freed
+                    // `Requested` slots are now `Missing` (release_peer above)
+                    // so other peers will refill them, and when the piece
+                    // completes `assembly.received_bytes` will equal
+                    // `expected_bytes`. Only drop the buffer if the dead peer
+                    // was the sole contributor — keeping an empty assembly
+                    // would just leak `piece_len` bytes per stalled piece.
+                    //
+                    // Invariant: every chunk index in `assembly.received_chunks`
+                    // corresponds to ChunkState::Received in the chunk tracker,
+                    // and release_peer only mutates Requested slots, so the
+                    // tracker stays consistent with the buffer
+                    let drop = piece_assemblies
+                        .get(&piece_idx)
+                        .is_none_or(|a| a.received_chunks.is_empty());
+                    if drop {
+                        piece_assemblies.remove(&piece_idx);
+                    }
                 }
             }
         }
@@ -850,6 +885,9 @@ async fn process_verify_result(
             "piece {} disk write failed; will re-request",
             vr.piece_index
         );
+        // Stop any other endgame peer still streaming chunks of this piece;
+        // they'd race the fresh re-request and force another reset
+        cancel_piece_outstanding(peers, vr.piece_index);
         chunk_tracker.reset_piece(vpi);
         return;
     }
@@ -862,6 +900,11 @@ async fn process_verify_result(
             // in-flight pieces rather than the torrent's lifetime
             // piece count
             chunk_tracker.forget_piece(vpi);
+            // Tell every peer to stop sending the rest of this piece.
+            // Without this, endgame duplicates of the remaining chunks
+            // keep arriving (silently dropped by the has_local guard)
+            // and saturate downstream during the final pieces
+            cancel_piece_outstanding(peers, vr.piece_index);
             broadcast_have(peers, vr.piece_index).await;
             let mut s = stats.lock();
             s.progress_bytes = completed_bytes(piece_tracker, lengths);
@@ -870,6 +913,9 @@ async fn process_verify_result(
         }
         _ => {
             log::debug!("piece {} hash mismatch", vr.piece_index);
+            // Same reasoning as write_failed: stale chunks from the prior
+            // attempt would interleave with the re-request
+            cancel_piece_outstanding(peers, vr.piece_index);
             chunk_tracker.reset_piece(vpi);
         }
     }
@@ -912,6 +958,69 @@ async fn drive_requests(
 /// Called both on the tick and inline after events that can unblock a peer
 /// (Unchoke, Bitfield, Have, Piece). Without the inline calls, throughput
 /// is capped at `max_outstanding * CHUNK_SIZE / tick_interval`
+/// Send a `Cancel` message to every peer (other than `except_pid`) that has
+/// the chunk `(index, begin, length)` in its outstanding queue, and remove
+/// the entry from each peer's local outstanding Vec. Best-effort: if a
+/// peer's command channel is full or closed we skip it (the chunk will
+/// arrive and be dedup-dropped, no worse than today).
+///
+/// which is the only thing that keeps endgame mode from saturating downstream
+/// with duplicate blocks at the very end of a download
+fn cancel_outstanding(
+    peers: &mut HashMap<u32, Peer>,
+    except_pid: u32,
+    index: u32,
+    begin: u32,
+    length: u32,
+) {
+    for (&other_pid, other) in peers.iter_mut() {
+        if other_pid == except_pid {
+            continue;
+        }
+        let Some(slot) = other
+            .outstanding
+            .iter()
+            .position(|&(p, b, l)| p == index && b == begin && l == length)
+        else {
+            continue;
+        };
+        // Drop our local record first so a duplicate Piece response will be
+        // rejected as unsolicited even if the peer ignores Cancel
+        other.outstanding.swap_remove(slot);
+        let _ = other.cmd_tx.try_send(PeerCommand::Send(Message::Cancel {
+            index,
+            begin,
+            length,
+        }));
+    }
+}
+
+/// Send `Cancel` for every outstanding chunk request matching `piece_index`
+/// across every peer. Called when the piece is no longer needed — either
+/// because it was verified successfully (other peers' endgame duplicates
+/// would now be wasted bytes) or because it failed verification / disk write
+/// and is about to be re-requested from scratch (delivering stale chunks
+/// from the previous attempt would inflate received_bytes past the
+/// expected_bytes guard, forcing a second reset).
+fn cancel_piece_outstanding(peers: &mut HashMap<u32, Peer>, piece_index: u32) {
+    for other in peers.values_mut() {
+        let mut i = 0;
+        while i < other.outstanding.len() {
+            let (p, begin, length) = other.outstanding[i];
+            if p == piece_index {
+                other.outstanding.swap_remove(i);
+                let _ = other.cmd_tx.try_send(PeerCommand::Send(Message::Cancel {
+                    index: piece_index,
+                    begin,
+                    length,
+                }));
+            } else {
+                i += 1;
+            }
+        }
+    }
+}
+
 async fn drive_peer(
     pid: u32,
     peers: &mut HashMap<u32, Peer>,
@@ -925,19 +1034,39 @@ async fn drive_peer(
     if peer.peer_choking || !peer.am_interested {
         return;
     }
+    // Pieces this peer already attempted in this drive_peer call but for which
+    // next_chunk returned None (no chunk available for this peer, even under
+    // endgame). Tracked so the endgame fallback below — which uses
+    // PieceTracker::choose_piece (does NOT skip in_flight) — does not loop
+    // forever picking the same piece every iteration.
+    let mut exhausted: HashSet<u32> = HashSet::new();
     while peer.outstanding.len() < max_outstanding {
         // Use the peer id as a hint to distribute piece selection across
-        // peers, avoiding the scenario where every peer picks the same piece
-        let Some(piece) = piece_tracker.choose_requestable_piece(&peer.bitfield, pid) else {
-            // No requestable piece for this peer. If we're near completion
-            // and a few stragglers are stuck on slow peers, flip on endgame
-            // mode so any peer can duplicate the request and finish the
-            // torrent. Without this, the last 1% can take minutes
-            if !chunk_tracker.endgame() && chunk_tracker.pending_chunks() <= 64 {
-                chunk_tracker.set_endgame(true);
-                continue;
+        // peers, avoiding the scenario where every peer picks the same piece.
+        //
+        // Endgame fallback: when no requestable (i.e. non-in-flight) piece
+        // remains, flip endgame on if we're near completion and then ask the
+        // tracker for ANY piece the peer has (including in-flight ones) that
+        // we haven't already exhausted this call. ChunkTracker::next_chunk's
+        // endgame branch will then duplicate another peer's outstanding chunk
+        // request. Without this fallback, the endgame flag is set but never
+        // observed, fast peers idle until REQUEST_TIMEOUT reclaims, and the
+        // last 1% takes minutes.
+        let piece = match piece_tracker.choose_requestable_piece(&peer.bitfield, pid) {
+            Some(p) if !exhausted.contains(&p.get()) => p,
+            _ => {
+                if !chunk_tracker.endgame() && chunk_tracker.pending_chunks() <= 64 {
+                    chunk_tracker.set_endgame(true);
+                }
+                if chunk_tracker.endgame() {
+                    match piece_tracker.choose_piece_excluding(&peer.bitfield, pid, &exhausted) {
+                        Some(p) => p,
+                        None => break,
+                    }
+                } else {
+                    break;
+                }
             }
-            break;
         };
         match chunk_tracker.next_chunk(piece, pid) {
             Some(chunk) => {
@@ -971,8 +1100,12 @@ async fn drive_peer(
             }
             None => {
                 // All chunks of this piece are already requested or received
-                // Mark it in-flight so we try a different piece next iteration
+                // (under endgame, also already requested by THIS peer). Mark
+                // in_flight so non-endgame `choose_requestable_piece` skips
+                // it, and record it locally so the endgame fallback path does
+                // not pick it again on the next loop iteration
                 piece_tracker.mark_in_flight(piece);
+                exhausted.insert(piece.get());
                 continue;
             }
         }

--- a/src-tauri/risuko-bt/src/torrent.rs
+++ b/src-tauri/risuko-bt/src/torrent.rs
@@ -743,7 +743,12 @@ async fn process_peer_event(
                     // request to stop sending it. Without this, redundant
                     // chunks keep saturating downstream and starve the
                     // remaining real requests near completion.
-                    if chunk_tracker.endgame() {
+                    // Guard with `accepted`: a duplicate Piece arrival in
+                    // endgame means we've already accepted this chunk before
+                    // (and already sent Cancel for it). Re-scanning every
+                    // peer's outstanding Vec for late duplicates is pure
+                    // O(n_peers) waste
+                    if accepted && chunk_tracker.endgame() {
                         cancel_outstanding(peers, pid, index, begin, chunk_len as u32);
                     }
                     let cinfo = super::core::ChunkInfo {
@@ -776,6 +781,7 @@ async fn process_peer_event(
                             // so just reset and re-request
                             piece_assemblies.remove(&index);
                             chunk_tracker.reset_piece(vpi);
+                            maybe_clear_endgame(chunk_tracker);
                             return kick;
                         }
                         assembly.completed = true;
@@ -848,10 +854,10 @@ async fn process_peer_event(
                     // corresponds to ChunkState::Received in the chunk tracker,
                     // and release_peer only mutates Requested slots, so the
                     // tracker stays consistent with the buffer
-                    let drop = piece_assemblies
+                    let should_drop = piece_assemblies
                         .get(&piece_idx)
                         .is_none_or(|a| a.received_chunks.is_empty());
-                    if drop {
+                    if should_drop {
                         piece_assemblies.remove(&piece_idx);
                     }
                 }
@@ -889,6 +895,7 @@ async fn process_verify_result(
         // they'd race the fresh re-request and force another reset
         cancel_piece_outstanding(peers, vr.piece_index);
         chunk_tracker.reset_piece(vpi);
+        maybe_clear_endgame(chunk_tracker);
         return;
     }
     match info.piece_hash(vr.piece_index) {
@@ -917,7 +924,20 @@ async fn process_verify_result(
             // attempt would interleave with the re-request
             cancel_piece_outstanding(peers, vr.piece_index);
             chunk_tracker.reset_piece(vpi);
+            maybe_clear_endgame(chunk_tracker);
         }
+    }
+}
+
+/// Clear the endgame flag once the working set has grown back above the
+/// activation threshold. Endgame is otherwise a one-way ratchet (set when
+/// `pending_chunks() <= 64`, never cleared), which prevents pieces re-queued
+/// via `reset_piece` after a hash/write failure from regaining the cheap
+/// sequential-scan path in `next_chunk` and forces every peer through the
+/// `choose_piece_excluding` fallback for the rest of the download
+fn maybe_clear_endgame(chunk_tracker: &mut ChunkTracker) {
+    if chunk_tracker.endgame() && chunk_tracker.pending_chunks() > 64 {
+        chunk_tracker.set_endgame(false);
     }
 }
 
@@ -954,18 +974,13 @@ async fn drive_requests(
     }
 }
 
-/// Pipeline requests for a single peer up to `max_outstanding`
-/// Called both on the tick and inline after events that can unblock a peer
-/// (Unchoke, Bitfield, Have, Piece). Without the inline calls, throughput
-/// is capped at `max_outstanding * CHUNK_SIZE / tick_interval`
 /// Send a `Cancel` message to every peer (other than `except_pid`) that has
 /// the chunk `(index, begin, length)` in its outstanding queue, and remove
 /// the entry from each peer's local outstanding Vec. Best-effort: if a
 /// peer's command channel is full or closed we skip it (the chunk will
-/// arrive and be dedup-dropped, no worse than today).
-///
-/// which is the only thing that keeps endgame mode from saturating downstream
-/// with duplicate blocks at the very end of a download
+/// arrive and be dedup-dropped, no worse than today). This is the only
+/// thing that keeps endgame mode from saturating downstream with duplicate
+/// blocks at the very end of a download.
 fn cancel_outstanding(
     peers: &mut HashMap<u32, Peer>,
     except_pid: u32,
@@ -1021,6 +1036,10 @@ fn cancel_piece_outstanding(peers: &mut HashMap<u32, Peer>, piece_index: u32) {
     }
 }
 
+/// Pipeline requests for a single peer up to `max_outstanding`.
+/// Called both on the tick and inline after events that can unblock a peer
+/// (Unchoke, Bitfield, Have, Piece). Without the inline calls, throughput
+/// is capped at `max_outstanding * CHUNK_SIZE / tick_interval`
 async fn drive_peer(
     pid: u32,
     peers: &mut HashMap<u32, Peer>,

--- a/src/renderer/shims/vue.d.ts
+++ b/src/renderer/shims/vue.d.ts
@@ -1,5 +1,6 @@
 declare module "*.vue" {
 	import type { DefineComponent } from "vue";
+
 	const component: DefineComponent<
 		Record<string, unknown>,
 		Record<string, unknown>,


### PR DESCRIPTION
- Reduce REQUEST_TIMEOUT from 20s to 8s for faster slow peer drain
- Add peer-derived offset in chunk selection to spread duplication across piece
- Implement cancel_outstanding() to suppress duplicate chunks mid-flight
- Add choose_piece_excluding() to prevent exhaustion loops
- Improve piece assembly buffer reuse when peer contributes chunks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added filtering capability for piece selection

* **Bug Fixes**
  * Optimized endgame chunk selection to better distribute peer requests
  * Reduced request timeout threshold for faster stale request recovery
  * Enhanced duplicate request cancellation in endgame mode
  * Improved piece reassembly buffer retention during peer disconnections

* **Chores**
  * Updated configuration schema reference

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speed up endgame and drain slow peers by distributing duplicate chunk requests across peers and canceling redundant blocks. Also reduces request timeout to 8s to cut the last-1% tail and stabilize throughput.

- **New Features**
  - Peer-aware endgame duplication: scans start at a stable peer-based offset to spread requests; fallback uses `choose_piece_excluding` to duplicate in-flight chunks without exhaustion loops.
  - Proactive Cancel: stop redundant blocks mid-flight and cancel all piece requests when a piece completes or is reset.

- **Bug Fixes**
  - Drop late duplicates and exclude them from throughput; keep piece buffers if other peers already contributed.
  - Faster recovery: reduce `REQUEST_TIMEOUT` to 8s and auto-clear endgame when the working set grows to restore normal scheduling.

<sup>Written for commit 803c534bff1042b7692f898a8fa32c928c705fca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

