### PR TITLE
feat(vault): add OS-keychain credential vault

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1039,6 +1039,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -1060,7 +1070,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.11.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -1073,7 +1083,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.11.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -1358,6 +1368,16 @@ dependencies = [
  "libc",
  "libdbus-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dbus-secret-service"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
+dependencies = [
+ "dbus",
+ "zeroize",
 ]
 
 [[package]]
@@ -3209,6 +3229,21 @@ dependencies = [
  "bitflags 2.11.1",
  "serde",
  "unicode-segmentation",
+]
+
+[[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "byteorder",
+ "dbus-secret-service",
+ "log",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
+ "windows-sys 0.60.2",
+ "zeroize",
 ]
 
 [[package]]
@@ -5340,6 +5375,7 @@ dependencies = [
  "base64 0.22.1",
  "clap",
  "dirs 6.0.0",
+ "keyring",
  "log",
  "open",
  "regex",
@@ -5826,6 +5862,42 @@ dependencies = [
  "pkcs8 0.10.2",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -6535,7 +6607,7 @@ checksum = "9103edf55f2da3c82aea4c7fab7c4241032bfeea0e71fa557d98e00e7ce7cc20"
 dependencies = [
  "bitflags 2.11.1",
  "block2",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
  "dispatch2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -70,6 +70,7 @@ base64 = "0.22"
 sha1 = "0.11"
 sha2 = "0.11"
 urlencoding = "2"
+keyring = { version = "3", features = ["apple-native", "windows-native", "sync-secret-service"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/risuko-engine/src/config/mod.rs
+++ b/src-tauri/risuko-engine/src/config/mod.rs
@@ -230,10 +230,7 @@ mod tests {
     fn config_manager_with_dir_uses_defaults_when_missing() {
         let dir = TempDir::new().unwrap();
         let mgr = ConfigManager::with_dir(dir.path().to_path_buf()).unwrap();
-        // Files are not eagerly created; defaults are returned in-memory
-        assert!(!dir.path().join("system.json").exists());
-        assert!(!dir.path().join("user.json").exists());
-        // Defaults should be present
+        // Defaults should be present when files are missing
         assert!(mgr.get_system_config().contains_key("all-proxy"));
         assert!(mgr.get_user_config().contains_key("theme"));
     }
@@ -306,6 +303,10 @@ mod tests {
         mgr.remove_system_config_key("a").unwrap();
         assert!(!mgr.get_system_config().contains_key("a"));
         assert!(mgr.get_system_config().contains_key("b"));
+        // Verify persistence by reopening
+        let mgr2 = ConfigManager::with_dir(dir.path().to_path_buf()).unwrap();
+        assert!(!mgr2.get_system_config().contains_key("a"));
+        assert!(mgr2.get_system_config().contains_key("b"));
     }
 
     #[test]

--- a/src-tauri/risuko-engine/src/config/mod.rs
+++ b/src-tauri/risuko-engine/src/config/mod.rs
@@ -202,6 +202,7 @@ fn parse_f64_like(value: Option<&Value>) -> Option<f64> {
 mod tests {
     use super::*;
     use serde_json::json;
+    use tempfile::TempDir;
 
     // -- parse_keep_seeding_option --
 
@@ -221,5 +222,117 @@ mod tests {
                 s
             );
         }
+    }
+
+    // -- ConfigManager --
+
+    #[test]
+    fn config_manager_with_dir_uses_defaults_when_missing() {
+        let dir = TempDir::new().unwrap();
+        let mgr = ConfigManager::with_dir(dir.path().to_path_buf()).unwrap();
+        // Files are not eagerly created; defaults are returned in-memory
+        assert!(!dir.path().join("system.json").exists());
+        assert!(!dir.path().join("user.json").exists());
+        // Defaults should be present
+        assert!(mgr.get_system_config().contains_key("all-proxy"));
+        assert!(mgr.get_user_config().contains_key("theme"));
+    }
+
+    #[test]
+    fn get_merged_config_combines_system_and_user() {
+        let dir = TempDir::new().unwrap();
+        let mut mgr = ConfigManager::with_dir(dir.path().to_path_buf()).unwrap();
+        mgr.set_system_config_map(&serde_json::from_str(r#"{"system-key": "sys-val"}"#).unwrap())
+            .unwrap();
+        mgr.set_user_config_map(&serde_json::from_str(r#"{"user-key": "user-val"}"#).unwrap())
+            .unwrap();
+
+        let merged = mgr.get_merged_config();
+        let map = merged.as_object().unwrap();
+        assert_eq!(map.get("system-key"), Some(&json!("sys-val")));
+        assert_eq!(map.get("user-key"), Some(&json!("user-val")));
+        assert!(map.contains_key("platform"));
+        assert!(map.contains_key("arch"));
+    }
+
+    #[test]
+    fn user_config_overrides_system_config() {
+        let dir = TempDir::new().unwrap();
+        let mut mgr = ConfigManager::with_dir(dir.path().to_path_buf()).unwrap();
+        mgr.set_system_config_map(&serde_json::from_str(r#"{"shared": "system"}"#).unwrap())
+            .unwrap();
+        mgr.set_user_config_map(&serde_json::from_str(r#"{"shared": "user"}"#).unwrap())
+            .unwrap();
+
+        let merged = mgr.get_merged_config();
+        let map = merged.as_object().unwrap();
+        assert_eq!(map.get("shared"), Some(&json!("user")));
+    }
+
+    #[test]
+    fn set_system_config_map_persists() {
+        let dir = TempDir::new().unwrap();
+        {
+            let mut mgr = ConfigManager::with_dir(dir.path().to_path_buf()).unwrap();
+            mgr.set_system_config_map(&serde_json::from_str(r#"{"persisted": true}"#).unwrap())
+                .unwrap();
+        }
+        // Re-open and verify
+        let mgr2 = ConfigManager::with_dir(dir.path().to_path_buf()).unwrap();
+        assert_eq!(
+            mgr2.get_system_config().get("persisted"),
+            Some(&json!(true))
+        );
+    }
+
+    #[test]
+    fn set_user_config_map_persists() {
+        let dir = TempDir::new().unwrap();
+        {
+            let mut mgr = ConfigManager::with_dir(dir.path().to_path_buf()).unwrap();
+            mgr.set_user_config_map(&serde_json::from_str(r#"{"locale": "zh-CN"}"#).unwrap())
+                .unwrap();
+        }
+        let mgr2 = ConfigManager::with_dir(dir.path().to_path_buf()).unwrap();
+        assert_eq!(mgr2.get_user_config().get("locale"), Some(&json!("zh-CN")));
+    }
+
+    #[test]
+    fn remove_system_config_key() {
+        let dir = TempDir::new().unwrap();
+        let mut mgr = ConfigManager::with_dir(dir.path().to_path_buf()).unwrap();
+        mgr.set_system_config_map(&serde_json::from_str(r#"{"a": 1, "b": 2}"#).unwrap())
+            .unwrap();
+        mgr.remove_system_config_key("a").unwrap();
+        assert!(!mgr.get_system_config().contains_key("a"));
+        assert!(mgr.get_system_config().contains_key("b"));
+    }
+
+    #[test]
+    fn reset_restores_defaults() {
+        let dir = TempDir::new().unwrap();
+        let mut mgr = ConfigManager::with_dir(dir.path().to_path_buf()).unwrap();
+        mgr.set_user_config_map(&serde_json::from_str(r#"{"locale": "custom"}"#).unwrap())
+            .unwrap();
+        mgr.set_system_config_map(&serde_json::from_str(r#"{"dir": "/tmp"}"#).unwrap())
+            .unwrap();
+        mgr.reset().unwrap();
+
+        let merged = mgr.get_merged_config();
+        let map = merged.as_object().unwrap();
+        assert_eq!(map.get("locale"), Some(&json!("en-US")));
+    }
+
+    #[test]
+    fn load_or_default_fills_missing_keys() {
+        let dir = TempDir::new().unwrap();
+        let user_path = dir.path().join("user.json");
+        fs::write(&user_path, r#"{"locale": "fr-FR"}"#).unwrap();
+
+        let mgr = ConfigManager::with_dir(dir.path().to_path_buf()).unwrap();
+        let user = mgr.get_user_config();
+        assert_eq!(user.get("locale"), Some(&json!("fr-FR")));
+        // theme should be filled from defaults
+        assert!(user.contains_key("theme"));
     }
 }

--- a/src-tauri/risuko-engine/src/engine/rss/mod.rs
+++ b/src-tauri/risuko-engine/src/engine/rss/mod.rs
@@ -650,3 +650,441 @@ fn matches_pattern(pattern: &str, is_regex: bool, text: &str) -> bool {
         lower_text.contains(&lower_pattern)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::traits::{FileStorage, NoopEventSink};
+    use tempfile::TempDir;
+
+    fn test_manager() -> RssManager {
+        let dir = TempDir::new().unwrap();
+        let storage: Arc<dyn StorageBackend> = Arc::new(FileStorage::new(dir.path().to_path_buf()));
+        let event_sink: Arc<dyn EventSink> = Arc::new(NoopEventSink);
+        RssManager::new(storage, event_sink)
+    }
+
+    fn sample_feed(id: &str, url: &str) -> RssFeed {
+        RssFeed {
+            id: id.into(),
+            url: url.into(),
+            title: "Test Feed".into(),
+            site_link: "https://example.com".into(),
+            description: "desc".into(),
+            update_interval_secs: DEFAULT_UPDATE_INTERVAL_SECS,
+            last_fetched_at: None,
+            created_at: 1,
+            is_active: true,
+            error_count: 0,
+        }
+    }
+
+    fn sample_item(feed_id: &str, item_id: &str, title: &str) -> RssItem {
+        RssItem {
+            id: item_id.into(),
+            feed_id: feed_id.into(),
+            title: title.into(),
+            link: "https://example.com/item".into(),
+            pub_date: Some(12345),
+            description: "desc".into(),
+            enclosure_url: Some("https://example.com/file.torrent".into()),
+            enclosure_type: None,
+            enclosure_length: None,
+            is_read: false,
+            is_downloaded: false,
+            download_path: None,
+        }
+    }
+
+    // -- Pure helpers --
+
+    #[test]
+    fn item_id_is_deterministic() {
+        let a = item_id("hello");
+        let b = item_id("hello");
+        let c = item_id("world");
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+        assert_eq!(a.len(), 64); // SHA-256 hex
+    }
+
+    #[test]
+    fn matches_pattern_substring() {
+        assert!(matches_pattern("hello", false, "Hello World"));
+        assert!(!matches_pattern("xyz", false, "Hello World"));
+    }
+
+    #[test]
+    fn matches_pattern_regex() {
+        assert!(matches_pattern(r"\d+", true, "Episode 42"));
+        assert!(!matches_pattern(r"^\d+$", true, "Episode 42"));
+    }
+
+    #[test]
+    fn matches_pattern_invalid_regex_returns_false() {
+        assert!(!matches_pattern(r"[invalid", true, "text"));
+    }
+
+    // -- RssManager CRUD --
+
+    #[test]
+    fn get_feeds_returns_populated() {
+        let mgr = test_manager();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        {
+            let mut s = mgr.store.blocking_lock();
+            s.feeds.push(sample_feed("f1", "https://a.com"));
+        }
+        let feeds = rt.block_on(mgr.get_feeds());
+        assert_eq!(feeds.len(), 1);
+        assert_eq!(feeds[0].id, "f1");
+    }
+
+    #[test]
+    fn get_items_returns_feed_items() {
+        let mgr = test_manager();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        {
+            let mut s = mgr.store.blocking_lock();
+            s.feeds.push(sample_feed("f1", "https://a.com"));
+            s.items
+                .insert("f1".into(), vec![sample_item("f1", "i1", "Item 1")]);
+        }
+        let items = rt.block_on(mgr.get_items("f1"));
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].title, "Item 1");
+    }
+
+    #[test]
+    fn get_items_missing_feed_returns_empty() {
+        let mgr = test_manager();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let items = rt.block_on(mgr.get_items("none"));
+        assert!(items.is_empty());
+    }
+
+    #[test]
+    fn remove_feed_deletes_items_and_rules() {
+        let mgr = test_manager();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        {
+            let mut s = mgr.store.blocking_lock();
+            s.feeds.push(sample_feed("f1", "https://a.com"));
+            s.items
+                .insert("f1".into(), vec![sample_item("f1", "i1", "Item 1")]);
+            s.rules.push(RssRule {
+                id: "r1".into(),
+                feed_id: Some("f1".into()),
+                name: "Rule".into(),
+                pattern: "*".into(),
+                is_regex: false,
+                is_active: true,
+                auto_download: true,
+                download_dir: None,
+            });
+        }
+        rt.block_on(mgr.remove_feed("f1")).unwrap();
+        let feeds = rt.block_on(mgr.get_feeds());
+        assert!(feeds.is_empty());
+        let items = rt.block_on(mgr.get_items("f1"));
+        assert!(items.is_empty());
+        let rules = rt.block_on(mgr.get_rules());
+        assert!(rules.is_empty());
+    }
+
+    #[test]
+    fn update_feed_settings_changes_interval_and_active() {
+        let mgr = test_manager();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        {
+            let mut s = mgr.store.blocking_lock();
+            s.feeds.push(sample_feed("f1", "https://a.com"));
+        }
+        rt.block_on(mgr.update_feed_settings("f1", Some(60), Some(false)))
+            .unwrap();
+        let feeds = rt.block_on(mgr.get_feeds());
+        assert_eq!(feeds[0].update_interval_secs, 60);
+        assert!(!feeds[0].is_active);
+    }
+
+    #[test]
+    fn update_feed_settings_not_found() {
+        let mgr = test_manager();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let err = rt
+            .block_on(mgr.update_feed_settings("none", Some(60), None))
+            .unwrap_err();
+        assert!(err.contains("not found"));
+    }
+
+    #[test]
+    fn mark_item_downloaded_updates_state() {
+        let mgr = test_manager();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        {
+            let mut s = mgr.store.blocking_lock();
+            s.feeds.push(sample_feed("f1", "https://a.com"));
+            s.items
+                .insert("f1".into(), vec![sample_item("f1", "i1", "Item 1")]);
+        }
+        rt.block_on(mgr.mark_item_downloaded("f1", "i1", Some("/downloads/file.txt".into())))
+            .unwrap();
+        let items = rt.block_on(mgr.get_items("f1"));
+        assert!(items[0].is_downloaded);
+        assert!(items[0].is_read);
+        assert_eq!(items[0].download_path, Some("/downloads/file.txt".into()));
+    }
+
+    #[test]
+    fn get_item_download_url_prefers_enclosure() {
+        let mgr = test_manager();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        {
+            let mut s = mgr.store.blocking_lock();
+            s.feeds.push(sample_feed("f1", "https://a.com"));
+            let mut item = sample_item("f1", "i1", "Item 1");
+            item.enclosure_url = Some("https://enc.example.com/file.torrent".into());
+            item.link = "https://link.example.com/".into();
+            s.items.insert("f1".into(), vec![item]);
+        }
+        let url = rt.block_on(mgr.get_item_download_url("f1", "i1")).unwrap();
+        assert_eq!(url, "https://enc.example.com/file.torrent");
+    }
+
+    #[test]
+    fn get_item_download_url_falls_back_to_link() {
+        let mgr = test_manager();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        {
+            let mut s = mgr.store.blocking_lock();
+            s.feeds.push(sample_feed("f1", "https://a.com"));
+            let mut item = sample_item("f1", "i1", "Item 1");
+            item.enclosure_url = None;
+            item.link = "https://link.example.com/".into();
+            s.items.insert("f1".into(), vec![item]);
+        }
+        let url = rt.block_on(mgr.get_item_download_url("f1", "i1")).unwrap();
+        assert_eq!(url, "https://link.example.com/");
+    }
+
+    #[test]
+    fn get_item_download_url_no_url() {
+        let mgr = test_manager();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        {
+            let mut s = mgr.store.blocking_lock();
+            s.feeds.push(sample_feed("f1", "https://a.com"));
+            let mut item = sample_item("f1", "i1", "Item 1");
+            item.enclosure_url = None;
+            item.link = String::new();
+            s.items.insert("f1".into(), vec![item]);
+        }
+        let err = rt
+            .block_on(mgr.get_item_download_url("f1", "i1"))
+            .unwrap_err();
+        assert!(err.contains("No downloadable URL"));
+    }
+
+    #[test]
+    fn add_rule_generates_id_and_validates_regex() {
+        let mgr = test_manager();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let rule = RssRule {
+            id: String::new(),
+            feed_id: None,
+            name: "Global".into(),
+            pattern: r".*".into(),
+            is_regex: true,
+            is_active: true,
+            auto_download: false,
+            download_dir: None,
+        };
+        let created = rt.block_on(mgr.add_rule(rule)).unwrap();
+        assert!(!created.id.is_empty());
+        let rules = rt.block_on(mgr.get_rules());
+        assert_eq!(rules.len(), 1);
+    }
+
+    #[test]
+    fn add_rule_rejects_invalid_regex() {
+        let mgr = test_manager();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let rule = RssRule {
+            id: String::new(),
+            feed_id: None,
+            name: "Bad".into(),
+            pattern: r"[bad".into(),
+            is_regex: true,
+            is_active: true,
+            auto_download: false,
+            download_dir: None,
+        };
+        let err = rt.block_on(mgr.add_rule(rule)).unwrap_err();
+        assert!(err.contains("Invalid regex"));
+    }
+
+    #[test]
+    fn remove_rule_deletes() {
+        let mgr = test_manager();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let rule = RssRule {
+            id: String::new(),
+            feed_id: None,
+            name: "Rule".into(),
+            pattern: "test".into(),
+            is_regex: false,
+            is_active: true,
+            auto_download: true,
+            download_dir: None,
+        };
+        let created = rt.block_on(mgr.add_rule(rule)).unwrap();
+        rt.block_on(mgr.remove_rule(&created.id)).unwrap();
+        let rules = rt.block_on(mgr.get_rules());
+        assert!(rules.is_empty());
+    }
+
+    #[test]
+    fn match_rules_substring() {
+        let mgr = test_manager();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(mgr.add_rule(RssRule {
+            id: "r1".into(),
+            feed_id: Some("f1".into()),
+            name: "Match".into(),
+            pattern: "hello".into(),
+            is_regex: false,
+            is_active: true,
+            auto_download: true,
+            download_dir: None,
+        }))
+        .unwrap();
+        let item = RssItem {
+            id: "i1".into(),
+            feed_id: "f1".into(),
+            title: "Hello World".into(),
+            link: String::new(),
+            pub_date: None,
+            description: String::new(),
+            enclosure_url: None,
+            enclosure_type: None,
+            enclosure_length: None,
+            is_read: false,
+            is_downloaded: false,
+            download_path: None,
+        };
+        let matched = rt.block_on(mgr.match_rules(&item));
+        assert!(matched.is_some());
+    }
+
+    #[test]
+    fn match_rules_respects_feed_scope() {
+        let mgr = test_manager();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(mgr.add_rule(RssRule {
+            id: "r1".into(),
+            feed_id: Some("f1".into()),
+            name: "Scope".into(),
+            pattern: "hello".into(),
+            is_regex: false,
+            is_active: true,
+            auto_download: true,
+            download_dir: None,
+        }))
+        .unwrap();
+        let item = RssItem {
+            id: "i1".into(),
+            feed_id: "f2".into(),
+            title: "Hello World".into(),
+            link: String::new(),
+            pub_date: None,
+            description: String::new(),
+            enclosure_url: None,
+            enclosure_type: None,
+            enclosure_length: None,
+            is_read: false,
+            is_downloaded: false,
+            download_path: None,
+        };
+        let matched = rt.block_on(mgr.match_rules(&item));
+        assert!(matched.is_none());
+    }
+
+    #[test]
+    fn match_rules_skips_inactive() {
+        let mgr = test_manager();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(mgr.add_rule(RssRule {
+            id: "r1".into(),
+            feed_id: None,
+            name: "Inactive".into(),
+            pattern: "hello".into(),
+            is_regex: false,
+            is_active: false,
+            auto_download: true,
+            download_dir: None,
+        }))
+        .unwrap();
+        let item = RssItem {
+            id: "i1".into(),
+            feed_id: "f1".into(),
+            title: "Hello World".into(),
+            link: String::new(),
+            pub_date: None,
+            description: String::new(),
+            enclosure_url: None,
+            enclosure_type: None,
+            enclosure_length: None,
+            is_read: false,
+            is_downloaded: false,
+            download_path: None,
+        };
+        let matched = rt.block_on(mgr.match_rules(&item));
+        assert!(matched.is_none());
+    }
+
+    #[test]
+    fn delete_items_removes_selected() {
+        let mgr = test_manager();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        {
+            let mut s = mgr.store.blocking_lock();
+            s.feeds.push(sample_feed("f1", "https://a.com"));
+            s.items.insert(
+                "f1".into(),
+                vec![
+                    sample_item("f1", "i1", "A"),
+                    sample_item("f1", "i2", "B"),
+                    sample_item("f1", "i3", "C"),
+                ],
+            );
+        }
+        rt.block_on(mgr.delete_items(vec![("f1".into(), vec!["i1".into(), "i3".into()])]))
+            .unwrap();
+        let items = rt.block_on(mgr.get_items("f1"));
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].id, "i2");
+    }
+
+    #[test]
+    fn load_and_save_round_trip() {
+        let dir = TempDir::new().unwrap();
+        let storage: Arc<dyn StorageBackend> = Arc::new(FileStorage::new(dir.path().to_path_buf()));
+        let event_sink: Arc<dyn EventSink> = Arc::new(NoopEventSink);
+        let mgr = RssManager::new(storage.clone(), event_sink.clone());
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        {
+            let mut s = mgr.store.blocking_lock();
+            s.feeds.push(sample_feed("f1", "https://a.com"));
+            s.items
+                .insert("f1".into(), vec![sample_item("f1", "i1", "Item")]);
+        }
+        rt.block_on(mgr.save()).unwrap();
+
+        let mgr2 = RssManager::new(storage, event_sink);
+        mgr2.load().unwrap();
+        let feeds = rt.block_on(mgr2.get_feeds());
+        assert_eq!(feeds.len(), 1);
+        let items = rt.block_on(mgr2.get_items("f1"));
+        assert_eq!(items.len(), 1);
+    }
+}

--- a/src-tauri/risuko-engine/src/engine/rss/mod.rs
+++ b/src-tauri/risuko-engine/src/engine/rss/mod.rs
@@ -657,11 +657,17 @@ mod tests {
     use crate::traits::{FileStorage, NoopEventSink};
     use tempfile::TempDir;
 
-    fn test_manager() -> RssManager {
+    struct RssTestCtx {
+        _dir: TempDir,
+        mgr: RssManager,
+    }
+
+    fn test_manager() -> RssTestCtx {
         let dir = TempDir::new().unwrap();
         let storage: Arc<dyn StorageBackend> = Arc::new(FileStorage::new(dir.path().to_path_buf()));
         let event_sink: Arc<dyn EventSink> = Arc::new(NoopEventSink);
-        RssManager::new(storage, event_sink)
+        let mgr = RssManager::new(storage, event_sink);
+        RssTestCtx { _dir: dir, mgr }
     }
 
     fn sample_feed(id: &str, url: &str) -> RssFeed {
@@ -729,7 +735,8 @@ mod tests {
 
     #[test]
     fn get_feeds_returns_populated() {
-        let mgr = test_manager();
+        let ctx = test_manager();
+        let mgr = &ctx.mgr;
         let rt = tokio::runtime::Runtime::new().unwrap();
         {
             let mut s = mgr.store.blocking_lock();
@@ -742,7 +749,8 @@ mod tests {
 
     #[test]
     fn get_items_returns_feed_items() {
-        let mgr = test_manager();
+        let ctx = test_manager();
+        let mgr = &ctx.mgr;
         let rt = tokio::runtime::Runtime::new().unwrap();
         {
             let mut s = mgr.store.blocking_lock();
@@ -757,7 +765,8 @@ mod tests {
 
     #[test]
     fn get_items_missing_feed_returns_empty() {
-        let mgr = test_manager();
+        let ctx = test_manager();
+        let mgr = &ctx.mgr;
         let rt = tokio::runtime::Runtime::new().unwrap();
         let items = rt.block_on(mgr.get_items("none"));
         assert!(items.is_empty());
@@ -765,7 +774,8 @@ mod tests {
 
     #[test]
     fn remove_feed_deletes_items_and_rules() {
-        let mgr = test_manager();
+        let ctx = test_manager();
+        let mgr = &ctx.mgr;
         let rt = tokio::runtime::Runtime::new().unwrap();
         {
             let mut s = mgr.store.blocking_lock();
@@ -794,7 +804,8 @@ mod tests {
 
     #[test]
     fn update_feed_settings_changes_interval_and_active() {
-        let mgr = test_manager();
+        let ctx = test_manager();
+        let mgr = &ctx.mgr;
         let rt = tokio::runtime::Runtime::new().unwrap();
         {
             let mut s = mgr.store.blocking_lock();
@@ -809,7 +820,8 @@ mod tests {
 
     #[test]
     fn update_feed_settings_not_found() {
-        let mgr = test_manager();
+        let ctx = test_manager();
+        let mgr = &ctx.mgr;
         let rt = tokio::runtime::Runtime::new().unwrap();
         let err = rt
             .block_on(mgr.update_feed_settings("none", Some(60), None))
@@ -819,7 +831,8 @@ mod tests {
 
     #[test]
     fn mark_item_downloaded_updates_state() {
-        let mgr = test_manager();
+        let ctx = test_manager();
+        let mgr = &ctx.mgr;
         let rt = tokio::runtime::Runtime::new().unwrap();
         {
             let mut s = mgr.store.blocking_lock();
@@ -837,7 +850,8 @@ mod tests {
 
     #[test]
     fn get_item_download_url_prefers_enclosure() {
-        let mgr = test_manager();
+        let ctx = test_manager();
+        let mgr = &ctx.mgr;
         let rt = tokio::runtime::Runtime::new().unwrap();
         {
             let mut s = mgr.store.blocking_lock();
@@ -853,7 +867,8 @@ mod tests {
 
     #[test]
     fn get_item_download_url_falls_back_to_link() {
-        let mgr = test_manager();
+        let ctx = test_manager();
+        let mgr = &ctx.mgr;
         let rt = tokio::runtime::Runtime::new().unwrap();
         {
             let mut s = mgr.store.blocking_lock();
@@ -869,7 +884,8 @@ mod tests {
 
     #[test]
     fn get_item_download_url_no_url() {
-        let mgr = test_manager();
+        let ctx = test_manager();
+        let mgr = &ctx.mgr;
         let rt = tokio::runtime::Runtime::new().unwrap();
         {
             let mut s = mgr.store.blocking_lock();
@@ -887,7 +903,8 @@ mod tests {
 
     #[test]
     fn add_rule_generates_id_and_validates_regex() {
-        let mgr = test_manager();
+        let ctx = test_manager();
+        let mgr = &ctx.mgr;
         let rt = tokio::runtime::Runtime::new().unwrap();
         let rule = RssRule {
             id: String::new(),
@@ -907,7 +924,8 @@ mod tests {
 
     #[test]
     fn add_rule_rejects_invalid_regex() {
-        let mgr = test_manager();
+        let ctx = test_manager();
+        let mgr = &ctx.mgr;
         let rt = tokio::runtime::Runtime::new().unwrap();
         let rule = RssRule {
             id: String::new(),
@@ -925,7 +943,8 @@ mod tests {
 
     #[test]
     fn remove_rule_deletes() {
-        let mgr = test_manager();
+        let ctx = test_manager();
+        let mgr = &ctx.mgr;
         let rt = tokio::runtime::Runtime::new().unwrap();
         let rule = RssRule {
             id: String::new(),
@@ -945,7 +964,8 @@ mod tests {
 
     #[test]
     fn match_rules_substring() {
-        let mgr = test_manager();
+        let ctx = test_manager();
+        let mgr = &ctx.mgr;
         let rt = tokio::runtime::Runtime::new().unwrap();
         rt.block_on(mgr.add_rule(RssRule {
             id: "r1".into(),
@@ -978,7 +998,8 @@ mod tests {
 
     #[test]
     fn match_rules_respects_feed_scope() {
-        let mgr = test_manager();
+        let ctx = test_manager();
+        let mgr = &ctx.mgr;
         let rt = tokio::runtime::Runtime::new().unwrap();
         rt.block_on(mgr.add_rule(RssRule {
             id: "r1".into(),
@@ -1011,7 +1032,8 @@ mod tests {
 
     #[test]
     fn match_rules_skips_inactive() {
-        let mgr = test_manager();
+        let ctx = test_manager();
+        let mgr = &ctx.mgr;
         let rt = tokio::runtime::Runtime::new().unwrap();
         rt.block_on(mgr.add_rule(RssRule {
             id: "r1".into(),
@@ -1044,7 +1066,8 @@ mod tests {
 
     #[test]
     fn delete_items_removes_selected() {
-        let mgr = test_manager();
+        let ctx = test_manager();
+        let mgr = &ctx.mgr;
         let rt = tokio::runtime::Runtime::new().unwrap();
         {
             let mut s = mgr.store.blocking_lock();

--- a/src-tauri/risuko-engine/src/engine/upload/manager.rs
+++ b/src-tauri/risuko-engine/src/engine/upload/manager.rs
@@ -783,6 +783,283 @@ fn merge_secrets(new: &mut SinkConfig, old: &SinkConfig) {
 mod tests {
     use super::*;
     use crate::engine::upload::sink::{FtpConfig, S3Config, SftpConfig, SinkConfig, WebdavConfig};
+    use crate::traits::{FileStorage, NoopEventSink};
+    use tempfile::TempDir;
+
+    fn test_manager() -> UploadSinkManager {
+        let dir = TempDir::new().unwrap();
+        let storage: Arc<dyn crate::traits::StorageBackend> =
+            Arc::new(FileStorage::new(dir.path().to_path_buf()));
+        let event_sink: Arc<dyn crate::traits::EventSink> = Arc::new(NoopEventSink);
+        UploadSinkManager::new(storage, event_sink)
+    }
+
+    fn sftp_config() -> SinkConfig {
+        SinkConfig::Sftp(SftpConfig {
+            host: "sftp.example.com".into(),
+            port: 22,
+            username: "u".into(),
+            password: "p".into(),
+            private_key: String::new(),
+            base_path: "/uploads".into(),
+        })
+    }
+
+    fn ftp_config() -> SinkConfig {
+        SinkConfig::Ftp(FtpConfig {
+            host: "ftp.example.com".into(),
+            port: 21,
+            username: "u".into(),
+            password: "p".into(),
+            base_path: "/uploads".into(),
+            secure: false,
+            insecure: false,
+        })
+    }
+
+    // -- UploadSinkManager CRUD --
+
+    #[test]
+    fn add_sink_generates_id_and_created_at() {
+        let mgr = test_manager();
+        let record = UploadSinkRecord {
+            id: String::new(),
+            label: "Test".into(),
+            config: sftp_config(),
+            post_action: PostUploadAction::Keep,
+            move_target: None,
+            created_at: 0,
+            last_used_at: None,
+        };
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let created = rt.block_on(mgr.add_sink(record)).unwrap();
+        assert!(!created.id.is_empty());
+        assert!(created.created_at > 0);
+    }
+
+    #[test]
+    fn add_sink_sets_default_when_first() {
+        let mgr = test_manager();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let created = rt
+            .block_on(mgr.add_sink(UploadSinkRecord {
+                id: String::new(),
+                label: "First".into(),
+                config: sftp_config(),
+                post_action: PostUploadAction::Keep,
+                move_target: None,
+                created_at: 0,
+                last_used_at: None,
+            }))
+            .unwrap();
+        let default_id = rt.block_on(mgr.default_sink_id());
+        assert_eq!(default_id, Some(created.id));
+    }
+
+    #[test]
+    fn add_sink_rejects_duplicate_id() {
+        let mgr = test_manager();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let created = rt
+            .block_on(mgr.add_sink(UploadSinkRecord {
+                id: String::new(),
+                label: "First".into(),
+                config: sftp_config(),
+                post_action: PostUploadAction::Keep,
+                move_target: None,
+                created_at: 0,
+                last_used_at: None,
+            }))
+            .unwrap();
+        let duplicate = rt.block_on(mgr.add_sink(UploadSinkRecord {
+            id: created.id.clone(),
+            label: "Duplicate".into(),
+            config: ftp_config(),
+            post_action: PostUploadAction::Keep,
+            move_target: None,
+            created_at: 0,
+            last_used_at: None,
+        }));
+        assert!(duplicate.is_err());
+    }
+
+    #[test]
+    fn list_sinks_returns_added() {
+        let mgr = test_manager();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(mgr.add_sink(UploadSinkRecord {
+            id: String::new(),
+            label: "A".into(),
+            config: sftp_config(),
+            post_action: PostUploadAction::Keep,
+            move_target: None,
+            created_at: 0,
+            last_used_at: None,
+        }))
+        .unwrap();
+        let sinks = rt.block_on(mgr.list_sinks());
+        assert_eq!(sinks.len(), 1);
+        assert_eq!(sinks[0].label, "A");
+    }
+
+    #[test]
+    fn update_sink_modifies_label() {
+        let mgr = test_manager();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let created = rt
+            .block_on(mgr.add_sink(UploadSinkRecord {
+                id: String::new(),
+                label: "Old".into(),
+                config: sftp_config(),
+                post_action: PostUploadAction::Keep,
+                move_target: None,
+                created_at: 0,
+                last_used_at: None,
+            }))
+            .unwrap();
+        let mut updated = created.clone();
+        updated.label = "New".into();
+        rt.block_on(mgr.update_sink(updated)).unwrap();
+        let sinks = rt.block_on(mgr.list_sinks());
+        assert_eq!(sinks[0].label, "New");
+    }
+
+    #[test]
+    fn update_sink_inherits_secrets_when_empty() {
+        let mgr = test_manager();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let created = rt
+            .block_on(mgr.add_sink(UploadSinkRecord {
+                id: String::new(),
+                label: "A".into(),
+                config: sftp_config(),
+                post_action: PostUploadAction::Keep,
+                move_target: None,
+                created_at: 0,
+                last_used_at: None,
+            }))
+            .unwrap();
+        let mut updated = created.clone();
+        // Clear password and private key — merge_secrets should preserve them
+        if let SinkConfig::Sftp(ref mut c) = updated.config {
+            c.password.clear();
+            c.private_key.clear();
+        }
+        rt.block_on(mgr.update_sink(updated)).unwrap();
+        let sinks = rt.block_on(mgr.list_sinks());
+        if let SinkConfig::Sftp(ref c) = sinks[0].config {
+            assert_eq!(c.password, "p");
+        } else {
+            panic!("expected sftp");
+        }
+    }
+
+    #[test]
+    fn remove_sink_deletes_and_updates_default() {
+        let mgr = test_manager();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let a = rt
+            .block_on(mgr.add_sink(UploadSinkRecord {
+                id: String::new(),
+                label: "A".into(),
+                config: sftp_config(),
+                post_action: PostUploadAction::Keep,
+                move_target: None,
+                created_at: 0,
+                last_used_at: None,
+            }))
+            .unwrap();
+        let b = rt
+            .block_on(mgr.add_sink(UploadSinkRecord {
+                id: String::new(),
+                label: "B".into(),
+                config: ftp_config(),
+                post_action: PostUploadAction::Keep,
+                move_target: None,
+                created_at: 0,
+                last_used_at: None,
+            }))
+            .unwrap();
+        // Default should be A (first)
+        assert_eq!(rt.block_on(mgr.default_sink_id()), Some(a.id.clone()));
+        rt.block_on(mgr.remove_sink(&a.id)).unwrap();
+        let sinks = rt.block_on(mgr.list_sinks());
+        assert_eq!(sinks.len(), 1);
+        assert_eq!(sinks[0].id, b.id);
+        // Default should fallback to B
+        assert_eq!(rt.block_on(mgr.default_sink_id()), Some(b.id.clone()));
+    }
+
+    #[test]
+    fn remove_sink_clears_default_when_last() {
+        let mgr = test_manager();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let a = rt
+            .block_on(mgr.add_sink(UploadSinkRecord {
+                id: String::new(),
+                label: "A".into(),
+                config: sftp_config(),
+                post_action: PostUploadAction::Keep,
+                move_target: None,
+                created_at: 0,
+                last_used_at: None,
+            }))
+            .unwrap();
+        rt.block_on(mgr.remove_sink(&a.id)).unwrap();
+        assert_eq!(rt.block_on(mgr.default_sink_id()), None);
+    }
+
+    #[test]
+    fn set_default_sink_validates() {
+        let mgr = test_manager();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let err = rt.block_on(mgr.set_default_sink(Some("nonexistent".into())));
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn set_max_concurrency_clamps_and_persists() {
+        let mgr = test_manager();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(mgr.set_max_concurrency(0)).unwrap();
+        // list_sinks doesn't expose concurrency; verify via load/save round-trip
+        // by creating a new manager with the same storage
+        // Since we used test_manager() which owns the TempDir, we can't re-open.
+        // Instead we verify the method doesn't error and the semaphore was swapped.
+        // A better approach: check that the store was persisted.
+        // We'll rely on the fact that set_max_concurrency calls save().
+        // No panic = success for this smoke test.
+        rt.block_on(mgr.set_max_concurrency(100)).unwrap();
+    }
+
+    #[test]
+    fn load_and_save_round_trip() {
+        let dir = TempDir::new().unwrap();
+        let storage: Arc<dyn crate::traits::StorageBackend> =
+            Arc::new(FileStorage::new(dir.path().to_path_buf()));
+        let event_sink: Arc<dyn crate::traits::EventSink> = Arc::new(NoopEventSink);
+        let mgr = UploadSinkManager::new(storage.clone(), event_sink.clone());
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let created = rt
+            .block_on(mgr.add_sink(UploadSinkRecord {
+                id: String::new(),
+                label: "Persisted".into(),
+                config: sftp_config(),
+                post_action: PostUploadAction::Move,
+                move_target: Some("/done".into()),
+                created_at: 0,
+                last_used_at: None,
+            }))
+            .unwrap();
+        // Create fresh manager pointing at same storage
+        let mgr2 = UploadSinkManager::new(storage, event_sink);
+        mgr2.load().unwrap();
+        let sinks = rt.block_on(mgr2.list_sinks());
+        assert_eq!(sinks.len(), 1);
+        assert_eq!(sinks[0].label, "Persisted");
+        assert_eq!(sinks[0].post_action, PostUploadAction::Move);
+        assert_eq!(rt.block_on(mgr2.default_sink_id()), Some(created.id));
+    }
 
     #[test]
     fn build_sink_runtime_webdav_ok() {

--- a/src-tauri/risuko-engine/src/engine/upload/manager.rs
+++ b/src-tauri/risuko-engine/src/engine/upload/manager.rs
@@ -786,12 +786,19 @@ mod tests {
     use crate::traits::{FileStorage, NoopEventSink};
     use tempfile::TempDir;
 
-    fn test_manager() -> UploadSinkManager {
+    struct UploadTestCtx {
+        #[allow(dead_code)]
+        dir: TempDir,
+        mgr: UploadSinkManager,
+    }
+
+    fn test_manager() -> UploadTestCtx {
         let dir = TempDir::new().unwrap();
         let storage: Arc<dyn crate::traits::StorageBackend> =
             Arc::new(FileStorage::new(dir.path().to_path_buf()));
         let event_sink: Arc<dyn crate::traits::EventSink> = Arc::new(NoopEventSink);
-        UploadSinkManager::new(storage, event_sink)
+        let mgr = UploadSinkManager::new(storage, event_sink);
+        UploadTestCtx { dir, mgr }
     }
 
     fn sftp_config() -> SinkConfig {
@@ -821,7 +828,8 @@ mod tests {
 
     #[test]
     fn add_sink_generates_id_and_created_at() {
-        let mgr = test_manager();
+        let ctx = test_manager();
+        let mgr = &ctx.mgr;
         let record = UploadSinkRecord {
             id: String::new(),
             label: "Test".into(),
@@ -839,7 +847,8 @@ mod tests {
 
     #[test]
     fn add_sink_sets_default_when_first() {
-        let mgr = test_manager();
+        let ctx = test_manager();
+        let mgr = &ctx.mgr;
         let rt = tokio::runtime::Runtime::new().unwrap();
         let created = rt
             .block_on(mgr.add_sink(UploadSinkRecord {
@@ -858,7 +867,8 @@ mod tests {
 
     #[test]
     fn add_sink_rejects_duplicate_id() {
-        let mgr = test_manager();
+        let ctx = test_manager();
+        let mgr = &ctx.mgr;
         let rt = tokio::runtime::Runtime::new().unwrap();
         let created = rt
             .block_on(mgr.add_sink(UploadSinkRecord {
@@ -885,7 +895,8 @@ mod tests {
 
     #[test]
     fn list_sinks_returns_added() {
-        let mgr = test_manager();
+        let ctx = test_manager();
+        let mgr = &ctx.mgr;
         let rt = tokio::runtime::Runtime::new().unwrap();
         rt.block_on(mgr.add_sink(UploadSinkRecord {
             id: String::new(),
@@ -904,7 +915,8 @@ mod tests {
 
     #[test]
     fn update_sink_modifies_label() {
-        let mgr = test_manager();
+        let ctx = test_manager();
+        let mgr = &ctx.mgr;
         let rt = tokio::runtime::Runtime::new().unwrap();
         let created = rt
             .block_on(mgr.add_sink(UploadSinkRecord {
@@ -926,7 +938,8 @@ mod tests {
 
     #[test]
     fn update_sink_inherits_secrets_when_empty() {
-        let mgr = test_manager();
+        let ctx = test_manager();
+        let mgr = &ctx.mgr;
         let rt = tokio::runtime::Runtime::new().unwrap();
         let created = rt
             .block_on(mgr.add_sink(UploadSinkRecord {
@@ -956,7 +969,8 @@ mod tests {
 
     #[test]
     fn remove_sink_deletes_and_updates_default() {
-        let mgr = test_manager();
+        let ctx = test_manager();
+        let mgr = &ctx.mgr;
         let rt = tokio::runtime::Runtime::new().unwrap();
         let a = rt
             .block_on(mgr.add_sink(UploadSinkRecord {
@@ -992,7 +1006,8 @@ mod tests {
 
     #[test]
     fn remove_sink_clears_default_when_last() {
-        let mgr = test_manager();
+        let ctx = test_manager();
+        let mgr = &ctx.mgr;
         let rt = tokio::runtime::Runtime::new().unwrap();
         let a = rt
             .block_on(mgr.add_sink(UploadSinkRecord {
@@ -1011,7 +1026,8 @@ mod tests {
 
     #[test]
     fn set_default_sink_validates() {
-        let mgr = test_manager();
+        let ctx = test_manager();
+        let mgr = &ctx.mgr;
         let rt = tokio::runtime::Runtime::new().unwrap();
         let err = rt.block_on(mgr.set_default_sink(Some("nonexistent".into())));
         assert!(err.is_err());
@@ -1019,7 +1035,8 @@ mod tests {
 
     #[test]
     fn set_max_concurrency_clamps_and_persists() {
-        let mgr = test_manager();
+        let ctx = test_manager();
+        let mgr = &ctx.mgr;
         let rt = tokio::runtime::Runtime::new().unwrap();
         rt.block_on(mgr.set_max_concurrency(0)).unwrap();
         // list_sinks doesn't expose concurrency; verify via load/save round-trip

--- a/src-tauri/risuko-engine/src/engine/upload/manager.rs
+++ b/src-tauri/risuko-engine/src/engine/upload/manager.rs
@@ -8,6 +8,7 @@ use std::sync::{Arc, Mutex as StdMutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use tokio::sync::{watch, Mutex, RwLock, Semaphore};
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
@@ -43,6 +44,11 @@ struct UploadStore {
     default_sink_id: Option<String>,
     #[serde(default = "default_concurrency")]
     max_concurrency: usize,
+    /// Fallback secret map used when the OS keychain vault is unavailable.
+    /// Each key is a sink id; the value is the JSON secrets object that
+    /// would normally live in the vault.
+    #[serde(default)]
+    secret_fallback: HashMap<String, Value>,
 }
 
 fn default_concurrency() -> usize {
@@ -149,6 +155,27 @@ impl UploadSinkManager {
         Ok(())
     }
 
+    // Fallback secret storage — used when the OS keychain vault is unavailable
+
+    pub async fn get_sink_secret_fallback(&self, id: &str) -> Option<Value> {
+        let s = self.store.read().await;
+        s.secret_fallback.get(id).cloned()
+    }
+
+    pub async fn put_sink_secret_fallback(&self, id: &str, secrets: &Value) -> Result<(), String> {
+        let mut s = self.store.write().await;
+        s.secret_fallback.insert(id.to_string(), secrets.clone());
+        drop(s);
+        self.save().await
+    }
+
+    pub async fn remove_sink_secret_fallback(&self, id: &str) -> Result<(), String> {
+        let mut s = self.store.write().await;
+        s.secret_fallback.remove(id);
+        drop(s);
+        self.save().await
+    }
+
     // queries
 
     pub async fn list_sinks(&self) -> Vec<UploadSinkRecord> {
@@ -236,6 +263,8 @@ impl UploadSinkManager {
         if s.default_sink_id.as_deref() == Some(id) {
             s.default_sink_id = s.sinks.first().map(|x| x.id.clone());
         }
+        // Clean up any fallback secrets so they don't leak after deletion
+        s.secret_fallback.remove(id);
         drop(s);
         self.save().await
     }

--- a/src-tauri/src/commands/config_cmds.rs
+++ b/src-tauri/src/commands/config_cmds.rs
@@ -191,3 +191,208 @@ fn apply_open_at_login(handle: &AppHandle, enabled: bool) -> Result<(), String> 
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // -- normalize_proxy_bypass --
+
+    #[test]
+    fn normalize_proxy_bypass_empty() {
+        assert_eq!(normalize_proxy_bypass(""), "");
+    }
+
+    #[test]
+    fn normalize_proxy_bypass_comma_and_newline() {
+        assert_eq!(
+            normalize_proxy_bypass("localhost, 127.0.0.1\n::1 , 192.168.1.1"),
+            "localhost,127.0.0.1,::1,192.168.1.1"
+        );
+    }
+
+    #[test]
+    fn normalize_proxy_bypass_trims_and_deduplicates_no_op() {
+        // Normalization does not deduplicate; it only trims and filters empties
+        assert_eq!(normalize_proxy_bypass("a, a, b"), "a,a,b");
+    }
+
+    // -- contains_download_scope --
+
+    #[test]
+    fn contains_download_scope_none() {
+        assert!(!contains_download_scope(None));
+    }
+
+    #[test]
+    fn contains_download_scope_missing() {
+        assert!(!contains_download_scope(Some(&json!("download"))));
+    }
+
+    #[test]
+    fn contains_download_scope_empty_array() {
+        assert!(!contains_download_scope(Some(&json!([]))));
+    }
+
+    #[test]
+    fn contains_download_scope_present() {
+        assert!(contains_download_scope(Some(&json!(["download"]))));
+    }
+
+    #[test]
+    fn contains_download_scope_present_with_spaces() {
+        assert!(contains_download_scope(Some(&json!(["  download  "]))));
+    }
+
+    #[test]
+    fn contains_download_scope_mixed_array() {
+        assert!(contains_download_scope(Some(&json!([
+            "update", "download"
+        ]))));
+    }
+
+    #[test]
+    fn contains_download_scope_no_match() {
+        assert!(!contains_download_scope(Some(&json!([
+            "update", "tracker"
+        ]))));
+    }
+
+    // -- prepare_preference_patch --
+
+    #[test]
+    fn prepare_non_object_returns_empty_map() {
+        let result = prepare_preference_patch(json!("string")).unwrap();
+        let map = result.as_object().unwrap();
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn prepare_keep_seeding_false_zeroes_seed_options() {
+        let result = prepare_preference_patch(json!({"keep-seeding": false})).unwrap();
+        let map = result.as_object().unwrap();
+        assert_eq!(map.get("seed-time"), Some(&json!(0)));
+        assert_eq!(map.get("seed-ratio"), Some(&json!(0)));
+    }
+
+    #[test]
+    fn prepare_keep_seeding_true_leaves_seed_options_unchanged() {
+        let result = prepare_preference_patch(json!({"keep-seeding": true})).unwrap();
+        let map = result.as_object().unwrap();
+        assert!(!map.contains_key("seed-time"));
+        assert!(!map.contains_key("seed-ratio"));
+    }
+
+    #[test]
+    fn prepare_keep_seeding_string_true() {
+        let result = prepare_preference_patch(json!({"keep-seeding": "true"})).unwrap();
+        let map = result.as_object().unwrap();
+        assert!(!map.contains_key("seed-time"));
+    }
+
+    #[test]
+    fn prepare_use_remote_file_time_bool() {
+        let result = prepare_preference_patch(json!({"use-remote-file-time": true})).unwrap();
+        let map = result.as_object().unwrap();
+        assert_eq!(map.get("remote-time"), Some(&json!(true)));
+    }
+
+    #[test]
+    fn prepare_use_remote_file_time_string() {
+        let result = prepare_preference_patch(json!({"use-remote-file-time": "true"})).unwrap();
+        let map = result.as_object().unwrap();
+        assert_eq!(map.get("remote-time"), Some(&json!(true)));
+    }
+
+    #[test]
+    fn prepare_use_remote_file_time_false_string() {
+        let result = prepare_preference_patch(json!({"use-remote-file-time": "false"})).unwrap();
+        let map = result.as_object().unwrap();
+        assert_eq!(map.get("remote-time"), Some(&json!(false)));
+    }
+
+    #[test]
+    fn prepare_proxy_disabled_clears_all_proxy() {
+        let result = prepare_preference_patch(json!({
+            "proxy": {
+                "enable": false,
+                "server": "http://proxy.example.com:8080",
+                "scope": ["download"]
+            }
+        }))
+        .unwrap();
+        let map = result.as_object().unwrap();
+        assert_eq!(map.get("all-proxy"), Some(&json!("")));
+        assert_eq!(map.get("no-proxy"), Some(&json!("")));
+    }
+
+    #[test]
+    fn prepare_proxy_enabled_with_download_scope_sets_all_proxy() {
+        let result = prepare_preference_patch(json!({
+            "proxy": {
+                "enable": true,
+                "server": "http://proxy.example.com:8080",
+                "scope": ["download"],
+                "bypass": "localhost, 127.0.0.1"
+            }
+        }))
+        .unwrap();
+        let map = result.as_object().unwrap();
+        assert_eq!(
+            map.get("all-proxy"),
+            Some(&json!("http://proxy.example.com:8080"))
+        );
+        assert_eq!(map.get("no-proxy"), Some(&json!("localhost,127.0.0.1")));
+    }
+
+    #[test]
+    fn prepare_proxy_enabled_without_server_clears_all_proxy() {
+        let result = prepare_preference_patch(json!({
+            "proxy": {
+                "enable": true,
+                "server": "",
+                "scope": ["download"]
+            }
+        }))
+        .unwrap();
+        let map = result.as_object().unwrap();
+        assert_eq!(map.get("all-proxy"), Some(&json!("")));
+    }
+
+    #[test]
+    fn prepare_proxy_enabled_without_download_scope_clears_all_proxy() {
+        let result = prepare_preference_patch(json!({
+            "proxy": {
+                "enable": true,
+                "server": "http://proxy.example.com:8080",
+                "scope": ["update"]
+            }
+        }))
+        .unwrap();
+        let map = result.as_object().unwrap();
+        assert_eq!(map.get("all-proxy"), Some(&json!("")));
+        assert_eq!(map.get("no-proxy"), Some(&json!("")));
+    }
+
+    #[test]
+    fn prepare_proxy_missing_scope_treats_as_no_download() {
+        let result = prepare_preference_patch(json!({
+            "proxy": {
+                "enable": true,
+                "server": "http://proxy.example.com:8080"
+            }
+        }))
+        .unwrap();
+        let map = result.as_object().unwrap();
+        assert_eq!(map.get("all-proxy"), Some(&json!("")));
+    }
+
+    #[test]
+    fn prepare_preserves_unrelated_keys() {
+        let result = prepare_preference_patch(json!({"theme": "dark", "locale": "en-US"})).unwrap();
+        let map = result.as_object().unwrap();
+        assert_eq!(map.get("theme"), Some(&json!("dark")));
+        assert_eq!(map.get("locale"), Some(&json!("en-US")));
+    }
+}

--- a/src-tauri/src/commands/event_cmds.rs
+++ b/src-tauri/src/commands/event_cmds.rs
@@ -143,6 +143,37 @@ fn format_speed(bytes: u64) -> String {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::format_speed;
+
+    #[test]
+    fn format_speed_bytes() {
+        assert_eq!(format_speed(0), "0 B");
+        assert_eq!(format_speed(512), "512 B");
+        assert_eq!(format_speed(1023), "1023 B");
+    }
+
+    #[test]
+    fn format_speed_kb() {
+        assert_eq!(format_speed(1024), "1.0 KB");
+        assert_eq!(format_speed(1536), "1.5 KB");
+        assert_eq!(format_speed(1024 * 1024 - 1), "1024.0 KB");
+    }
+
+    #[test]
+    fn format_speed_mb() {
+        assert_eq!(format_speed(1024 * 1024), "1.0 MB");
+        assert_eq!(format_speed(1024 * 1024 * 15), "15.0 MB");
+    }
+
+    #[test]
+    fn format_speed_gb() {
+        assert_eq!(format_speed(1024 * 1024 * 1024), "1.0 GB");
+        assert_eq!(format_speed(1024 * 1024 * 1024 * 3), "3.0 GB");
+    }
+}
+
 fn apply_download_inhibit(downloading: bool) {
     #[cfg(target_os = "windows")]
     {

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -5,3 +5,4 @@ pub mod event_cmds;
 pub mod file_cmds;
 pub mod rss_cmds;
 pub mod upload_cmds;
+pub mod vault_cmds;

--- a/src-tauri/src/commands/upload_cmds.rs
+++ b/src-tauri/src/commands/upload_cmds.rs
@@ -119,12 +119,27 @@ fn apply_sink_secrets(config: &mut SinkConfig, secrets: &Value) {
 /// blank. Mirrors the engine's `merge_secrets` behavior (treat empty as
 /// "unchanged") so editing a sink without retyping the password keeps it
 /// working
-async fn fill_from_vault(vault: &VaultManager, mgr: &UploadSinkManager, id: &str, config: &mut SinkConfig) {
+async fn fill_from_vault(
+    vault: &VaultManager,
+    mgr: &UploadSinkManager,
+    id: &str,
+    config: &mut SinkConfig,
+) {
+    // Try vault first when enabled. If it returns a hit, use it. On
+    // `Ok(None)` (no entry) or `Err(_)` (backend hiccup), fall through to
+    // the durable local fallback so secrets that `persist_sink_secrets`
+    // wrote there during a prior vault failure remain recoverable
     if vault.enabled() {
-        if let Ok(Some(secrets)) = vault.get_sink(id) {
-            apply_sink_secrets(config, &secrets);
+        match vault.get_sink(id) {
+            Ok(Some(secrets)) => {
+                apply_sink_secrets(config, &secrets);
+                return;
+            }
+            Ok(None) => {}
+            Err(e) => {
+                log::warn!("Failed to load vault entry for sink {id}: {e}, trying fallback");
+            }
         }
-        return;
     }
     if let Some(secrets) = mgr.get_sink_secret_fallback(id).await {
         apply_sink_secrets(config, &secrets);
@@ -136,7 +151,12 @@ async fn fill_from_vault(vault: &VaultManager, mgr: &UploadSinkManager, id: &str
 /// are written to a durable fallback store inside the upload manager so
 /// they survive restarts. Failures are logged but never block the
 /// user-visible operation — the engine still has the runtime value in memory
-async fn persist_sink_secrets(vault: &VaultManager, mgr: &UploadSinkManager, id: &str, config: &SinkConfig) {
+async fn persist_sink_secrets(
+    vault: &VaultManager,
+    mgr: &UploadSinkManager,
+    id: &str,
+    config: &SinkConfig,
+) {
     match extract_sink_secrets(config) {
         Some(v) => {
             if vault.enabled() {
@@ -149,7 +169,9 @@ async fn persist_sink_secrets(vault: &VaultManager, mgr: &UploadSinkManager, id:
                         return;
                     }
                     Err(e) => {
-                        log::warn!("Failed to store sink secrets in vault for {id}: {e}, falling back");
+                        log::warn!(
+                            "Failed to store sink secrets in vault for {id}: {e}, falling back"
+                        );
                     }
                 }
             }
@@ -177,21 +199,27 @@ async fn persist_sink_secrets(vault: &VaultManager, mgr: &UploadSinkManager, id:
 pub async fn rehydrate_upload_sinks(mgr: &UploadSinkManager, vault: &VaultManager) {
     let sinks = mgr.list_sinks().await;
     for mut record in sinks {
-        let secrets = if vault.enabled() {
+        // Try vault first when enabled, but always fall through to the
+        // local fallback when the vault has no entry or errors — secrets
+        // written by `persist_sink_secrets` during a prior vault outage
+        // would otherwise be unrecoverable
+        let mut secrets: Option<Value> = None;
+        if vault.enabled() {
             match vault.get_sink(&record.id) {
-                Ok(Some(v)) => v,
-                Ok(None) => continue,
+                Ok(Some(v)) => secrets = Some(v),
+                Ok(None) => {}
                 Err(e) => {
-                    log::warn!("Failed to load vault entry for sink {}: {e}", record.id);
-                    continue;
+                    log::warn!(
+                        "Failed to load vault entry for sink {}: {e}, trying fallback",
+                        record.id
+                    );
                 }
             }
-        } else {
-            match mgr.get_sink_secret_fallback(&record.id).await {
-                Some(v) => v,
-                None => continue,
-            }
-        };
+        }
+        if secrets.is_none() {
+            secrets = mgr.get_sink_secret_fallback(&record.id).await;
+        }
+        let Some(secrets) = secrets else { continue };
         let id = record.id.clone();
         apply_sink_secrets(&mut record.config, &secrets);
         if let Err(e) = mgr.update_sink(record).await {
@@ -432,5 +460,56 @@ mod tests {
         }
     }
 
+    /// Regression: when the vault is enabled but its read returns no entry
+    /// (or errors), `fill_from_vault` must still consult the local
+    /// fallback store. Without this, secrets that `persist_sink_secrets`
+    /// wrote to the fallback during a prior vault outage become
+    /// unrecoverable on the very next edit
+    #[tokio::test]
+    async fn fill_from_vault_falls_back_when_vault_misses() {
+        use risuko_engine::traits::{FileStorage, NoopEventSink};
+        use std::sync::Arc;
 
+        let dir = tempfile::TempDir::new().unwrap();
+        let storage: Arc<dyn risuko_engine::traits::StorageBackend> =
+            Arc::new(FileStorage::new(dir.path().to_path_buf()));
+        let event_sink: Arc<dyn risuko_engine::traits::EventSink> = Arc::new(NoopEventSink);
+        let mgr = UploadSinkManager::new(storage, event_sink);
+
+        // Seed the manager's fallback store with a secret for an id the
+        // OS keychain cannot possibly know about (random uuid-ish suffix)
+        let id = format!("test-sink-{}-{}", std::process::id(), uuid_like());
+        let stored = json!({"password": "from-fallback", "privateKey": "pk"});
+        mgr.put_sink_secret_fallback(&id, &stored).await.unwrap();
+
+        // Force the vault into "enabled" without a real keychain probe.
+        // `vault.get_sink(&id)` will then return either Ok(None) (backend
+        // reachable, no entry) or Err(_) (no backend) — both code paths
+        // we want to confirm fall through to the fallback
+        let vault = crate::managers::vault::VaultManager::for_test(true);
+        assert!(vault.enabled());
+
+        let mut cfg = sftp("", "");
+        fill_from_vault(&vault, &mgr, &id, &mut cfg).await;
+        match cfg {
+            SinkConfig::Sftp(c) => {
+                assert_eq!(c.password, "from-fallback", "fallback password not applied");
+                assert_eq!(c.private_key, "pk", "fallback private key not applied");
+            }
+            _ => panic!("expected sftp"),
+        }
+    }
+
+    /// Tiny helper: avoids pulling in the `uuid` crate just for a unique
+    /// string in a single test
+    fn uuid_like() -> String {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        format!(
+            "{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        )
+    }
 }

--- a/src-tauri/src/commands/upload_cmds.rs
+++ b/src-tauri/src/commands/upload_cmds.rs
@@ -3,11 +3,12 @@
 
 use std::sync::Arc;
 
-use serde_json::Value;
+use serde_json::{json, Value};
 use tauri::State;
 
-use risuko_engine::engine::upload::{UploadRule, UploadSinkManager, UploadSinkRecord};
+use risuko_engine::engine::upload::{SinkConfig, UploadRule, UploadSinkManager, UploadSinkRecord};
 
+use crate::managers::vault::VaultManager;
 use crate::state::AppState;
 
 fn get_mgr(state: &State<'_, AppState>) -> Result<Arc<UploadSinkManager>, String> {
@@ -17,6 +18,158 @@ fn get_mgr(state: &State<'_, AppState>) -> Result<Arc<UploadSinkManager>, String
         .map_err(|e| e.to_string())?
         .clone()
         .ok_or_else(|| "Upload manager not initialized".to_string())
+}
+
+/// Extract the sensitive fields from a sink config into a JSON object
+/// suitable for keychain storage. Returns `None` when no secret is set
+/// (so callers can `remove()` instead of writing an empty object)
+fn extract_sink_secrets(config: &SinkConfig) -> Option<Value> {
+    let mut obj = serde_json::Map::new();
+    match config {
+        SinkConfig::Webdav(c) => {
+            if !c.password.is_empty() {
+                obj.insert("password".into(), json!(c.password));
+            }
+        }
+        SinkConfig::S3(c) => {
+            if !c.secret_access_key.is_empty() {
+                obj.insert("secretAccessKey".into(), json!(c.secret_access_key));
+            }
+        }
+        SinkConfig::Sftp(c) => {
+            if !c.password.is_empty() {
+                obj.insert("password".into(), json!(c.password));
+            }
+            if !c.private_key.is_empty() {
+                obj.insert("privateKey".into(), json!(c.private_key));
+            }
+        }
+        SinkConfig::Ftp(c) => {
+            if !c.password.is_empty() {
+                obj.insert("password".into(), json!(c.password));
+            }
+        }
+    }
+    if obj.is_empty() {
+        None
+    } else {
+        Some(Value::Object(obj))
+    }
+}
+
+/// Apply secrets pulled from the keychain back onto a sink config. Empty
+/// or missing fields are silently ignored so a partial vault entry never
+/// clobbers a value the user just typed
+fn apply_sink_secrets(config: &mut SinkConfig, secrets: &Value) {
+    let obj = match secrets.as_object() {
+        Some(o) => o,
+        None => return,
+    };
+    let s = |k: &str| {
+        obj.get(k)
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string()
+    };
+    match config {
+        SinkConfig::Webdav(c) => {
+            let v = s("password");
+            if !v.is_empty() {
+                c.password = v;
+            }
+        }
+        SinkConfig::S3(c) => {
+            let v = s("secretAccessKey");
+            if !v.is_empty() {
+                c.secret_access_key = v;
+            }
+        }
+        SinkConfig::Sftp(c) => {
+            let pw = s("password");
+            if !pw.is_empty() {
+                c.password = pw;
+            }
+            let pk = s("privateKey");
+            if !pk.is_empty() {
+                c.private_key = pk;
+            }
+        }
+        SinkConfig::Ftp(c) => {
+            let v = s("password");
+            if !v.is_empty() {
+                c.password = v;
+            }
+        }
+    }
+}
+
+/// Whether the sink config currently carries any plaintext secret. Used
+/// when deciding whether to clear a stale vault entry
+fn sink_has_secrets(config: &SinkConfig) -> bool {
+    match config {
+        SinkConfig::Webdav(c) => !c.password.is_empty(),
+        SinkConfig::S3(c) => !c.secret_access_key.is_empty(),
+        SinkConfig::Sftp(c) => !c.password.is_empty() || !c.private_key.is_empty(),
+        SinkConfig::Ftp(c) => !c.password.is_empty(),
+    }
+}
+
+/// Pull stored secrets from the vault into the config when the incoming
+/// record left them blank. Mirrors the engine's `merge_secrets` behavior
+/// (treat empty as "unchanged") so editing a sink without retyping the
+/// password keeps it working
+fn fill_from_vault(vault: &VaultManager, id: &str, config: &mut SinkConfig) {
+    if !vault.enabled() || sink_has_secrets(config) {
+        return;
+    }
+    if let Ok(Some(secrets)) = vault.get_sink(id) {
+        apply_sink_secrets(config, &secrets);
+    }
+}
+
+/// Persist a record's secrets to the vault, or remove the entry when no
+/// secret is set. Failures are logged but never block the user-visible
+/// operation — the engine still has the runtime value in memory
+fn persist_sink_secrets(vault: &VaultManager, id: &str, config: &SinkConfig) {
+    if !vault.enabled() {
+        return;
+    }
+    match extract_sink_secrets(config) {
+        Some(v) => {
+            if let Err(e) = vault.put_sink(id, &v) {
+                log::warn!("Failed to store sink secrets in vault for {id}: {e}");
+            }
+        }
+        None => {
+            if let Err(e) = vault.remove_sink(id) {
+                log::warn!("Failed to clear vault entry for sink {id}: {e}");
+            }
+        }
+    }
+}
+
+/// Rehydrate every loaded sink's secrets from the vault. Called once at
+/// startup after the upload manager loads its on-disk records (which omit
+/// secrets by design — see `skip_serializing` on the protocol Configs)
+pub async fn rehydrate_upload_sinks(mgr: &UploadSinkManager, vault: &VaultManager) {
+    if !vault.enabled() {
+        return;
+    }
+    let sinks = mgr.list_sinks().await;
+    for mut record in sinks {
+        let secrets = match vault.get_sink(&record.id) {
+            Ok(Some(v)) => v,
+            Ok(None) => continue,
+            Err(e) => {
+                log::warn!("Failed to load vault entry for sink {}: {e}", record.id);
+                continue;
+            }
+        };
+        apply_sink_secrets(&mut record.config, &secrets);
+        if let Err(e) = mgr.update_sink(record).await {
+            log::warn!("Failed to inject vault secrets into upload manager: {e}");
+        }
+    }
 }
 
 // -- sinks
@@ -34,23 +187,39 @@ pub async fn add_upload_sink(
     record: UploadSinkRecord,
 ) -> Result<Value, String> {
     let mgr = get_mgr(&state)?;
+    let vault = state.vault.clone();
     let created = mgr.add_sink(record).await?;
+    persist_sink_secrets(&vault, &created.id, &created.config);
     serde_json::to_value(created).map_err(|e| e.to_string())
 }
 
 #[tauri::command]
 pub async fn update_upload_sink(
     state: State<'_, AppState>,
-    record: UploadSinkRecord,
+    mut record: UploadSinkRecord,
 ) -> Result<(), String> {
     let mgr = get_mgr(&state)?;
-    mgr.update_sink(record).await
+    let vault = state.vault.clone();
+    // Empty incoming secrets mean "unchanged" — fill from vault before the
+    // engine's own merge_secrets fallback runs against a disk copy that
+    // never held the secret in the first place
+    fill_from_vault(&vault, &record.id, &mut record.config);
+    let id = record.id.clone();
+    let config_for_vault = record.config.clone();
+    mgr.update_sink(record).await?;
+    persist_sink_secrets(&vault, &id, &config_for_vault);
+    Ok(())
 }
 
 #[tauri::command]
 pub async fn remove_upload_sink(state: State<'_, AppState>, id: String) -> Result<(), String> {
     let mgr = get_mgr(&state)?;
-    mgr.remove_sink(&id).await
+    let vault = state.vault.clone();
+    mgr.remove_sink(&id).await?;
+    if let Err(e) = vault.remove_sink(&id) {
+        log::warn!("Failed to remove vault entry for sink {id}: {e}");
+    }
+    Ok(())
 }
 
 #[tauri::command]
@@ -137,4 +306,108 @@ pub async fn clear_upload_history(state: State<'_, AppState>) -> Result<(), Stri
     let mgr = get_mgr(&state)?;
     mgr.clear_history().await;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use risuko_engine::engine::upload::{FtpConfig, S3Config, SftpConfig, WebdavConfig};
+
+    fn sftp(password: &str, private_key: &str) -> SinkConfig {
+        SinkConfig::Sftp(SftpConfig {
+            host: "h".into(),
+            port: 22,
+            username: "u".into(),
+            password: password.into(),
+            private_key: private_key.into(),
+            base_path: String::new(),
+        })
+    }
+
+    #[test]
+    fn extract_returns_none_when_empty() {
+        assert!(extract_sink_secrets(&sftp("", "")).is_none());
+        assert!(extract_sink_secrets(&SinkConfig::Ftp(FtpConfig {
+            host: "h".into(),
+            port: 21,
+            username: String::new(),
+            password: String::new(),
+            base_path: String::new(),
+            secure: false,
+            insecure: false,
+        }))
+        .is_none());
+    }
+
+    #[test]
+    fn extract_picks_up_sftp_secrets() {
+        let v = extract_sink_secrets(&sftp("p", "k")).unwrap();
+        assert_eq!(v["password"], "p");
+        assert_eq!(v["privateKey"], "k");
+    }
+
+    #[test]
+    fn extract_picks_up_s3_secret() {
+        let cfg = SinkConfig::S3(S3Config {
+            endpoint: "e".into(),
+            region: String::new(),
+            bucket: "b".into(),
+            access_key_id: "a".into(),
+            secret_access_key: "shh".into(),
+            prefix: String::new(),
+            force_path_style: false,
+        });
+        let v = extract_sink_secrets(&cfg).unwrap();
+        assert_eq!(v["secretAccessKey"], "shh");
+    }
+
+    #[test]
+    fn apply_round_trips_sftp() {
+        let mut cfg = sftp("", "");
+        let payload = serde_json::json!({"password": "p", "privateKey": "k"});
+        apply_sink_secrets(&mut cfg, &payload);
+        match cfg {
+            SinkConfig::Sftp(c) => {
+                assert_eq!(c.password, "p");
+                assert_eq!(c.private_key, "k");
+            }
+            _ => panic!("expected sftp"),
+        }
+    }
+
+    #[test]
+    fn apply_does_not_clobber_with_empty() {
+        let mut cfg = sftp("existing", "");
+        // Empty fields in payload must NOT overwrite a value already typed.
+        let payload = serde_json::json!({"password": "", "privateKey": ""});
+        apply_sink_secrets(&mut cfg, &payload);
+        match cfg {
+            SinkConfig::Sftp(c) => assert_eq!(c.password, "existing"),
+            _ => panic!("expected sftp"),
+        }
+    }
+
+    #[test]
+    fn apply_ignores_unrelated_fields() {
+        let mut cfg = SinkConfig::Webdav(WebdavConfig {
+            endpoint: "e".into(),
+            base_path: String::new(),
+            username: String::new(),
+            password: String::new(),
+            insecure: false,
+        });
+        let payload = serde_json::json!({"privateKey": "x"}); // wrong field
+        apply_sink_secrets(&mut cfg, &payload);
+        match cfg {
+            SinkConfig::Webdav(c) => assert_eq!(c.password, ""),
+            _ => panic!("expected webdav"),
+        }
+    }
+
+    #[test]
+    fn sink_has_secrets_detects_each_variant() {
+        assert!(!sink_has_secrets(&sftp("", "")));
+        assert!(sink_has_secrets(&sftp("p", "")));
+        assert!(sink_has_secrets(&sftp("", "k")));
+    }
 }

--- a/src-tauri/src/commands/upload_cmds.rs
+++ b/src-tauri/src/commands/upload_cmds.rs
@@ -114,60 +114,88 @@ fn apply_sink_secrets(config: &mut SinkConfig, secrets: &Value) {
     }
 }
 
-/// Pull stored secrets from the vault into the config when the incoming
-/// record left them blank. Mirrors the engine's `merge_secrets` behavior
-/// (treat empty as "unchanged") so editing a sink without retyping the
-/// password keeps it working
-fn fill_from_vault(vault: &VaultManager, id: &str, config: &mut SinkConfig) {
-    if !vault.enabled() {
+/// Pull stored secrets from the vault (or the local fallback store when the
+/// vault is unavailable) into the config when the incoming record left them
+/// blank. Mirrors the engine's `merge_secrets` behavior (treat empty as
+/// "unchanged") so editing a sink without retyping the password keeps it
+/// working
+async fn fill_from_vault(vault: &VaultManager, mgr: &UploadSinkManager, id: &str, config: &mut SinkConfig) {
+    if vault.enabled() {
+        if let Ok(Some(secrets)) = vault.get_sink(id) {
+            apply_sink_secrets(config, &secrets);
+        }
         return;
     }
-    if let Ok(Some(secrets)) = vault.get_sink(id) {
+    if let Some(secrets) = mgr.get_sink_secret_fallback(id).await {
         apply_sink_secrets(config, &secrets);
     }
 }
 
 /// Persist a record's secrets to the vault, or remove the entry when no
-/// secret is set. Failures are logged but never block the user-visible
-/// operation — the engine still has the runtime value in memory
-fn persist_sink_secrets(vault: &VaultManager, id: &str, config: &SinkConfig) {
-    if !vault.enabled() {
-        return;
-    }
+/// secret is set. When the vault is disabled or returns an error, secrets
+/// are written to a durable fallback store inside the upload manager so
+/// they survive restarts. Failures are logged but never block the
+/// user-visible operation — the engine still has the runtime value in memory
+async fn persist_sink_secrets(vault: &VaultManager, mgr: &UploadSinkManager, id: &str, config: &SinkConfig) {
     match extract_sink_secrets(config) {
         Some(v) => {
-            if let Err(e) = vault.put_sink(id, &v) {
-                log::warn!("Failed to store sink secrets in vault for {id}: {e}");
+            if vault.enabled() {
+                match vault.put_sink(id, &v) {
+                    Ok(()) => {
+                        // Vault succeeded — clear any stale fallback entry
+                        if let Err(e) = mgr.remove_sink_secret_fallback(id).await {
+                            log::warn!("Failed to clear stale fallback for sink {id}: {e}");
+                        }
+                        return;
+                    }
+                    Err(e) => {
+                        log::warn!("Failed to store sink secrets in vault for {id}: {e}, falling back");
+                    }
+                }
+            }
+            if let Err(e) = mgr.put_sink_secret_fallback(id, &v).await {
+                log::warn!("Failed to store sink secrets in fallback for {id}: {e}");
             }
         }
         None => {
-            if let Err(e) = vault.remove_sink(id) {
-                log::warn!("Failed to clear vault entry for sink {id}: {e}");
+            if vault.enabled() {
+                if let Err(e) = vault.remove_sink(id) {
+                    log::warn!("Failed to clear vault entry for sink {id}: {e}");
+                }
+            }
+            if let Err(e) = mgr.remove_sink_secret_fallback(id).await {
+                log::warn!("Failed to clear fallback secrets for sink {id}: {e}");
             }
         }
     }
 }
 
-/// Rehydrate every loaded sink's secrets from the vault. Called once at
-/// startup after the upload manager loads its on-disk records (which omit
-/// secrets by design — see `skip_serializing` on the protocol Configs)
+/// Rehydrate every loaded sink's secrets from the vault (or from the local
+/// fallback store when the vault is unavailable). Called once at startup
+/// after the upload manager loads its on-disk records (which omit secrets
+/// by design — see `skip_serializing` on the protocol Configs)
 pub async fn rehydrate_upload_sinks(mgr: &UploadSinkManager, vault: &VaultManager) {
-    if !vault.enabled() {
-        return;
-    }
     let sinks = mgr.list_sinks().await;
     for mut record in sinks {
-        let secrets = match vault.get_sink(&record.id) {
-            Ok(Some(v)) => v,
-            Ok(None) => continue,
-            Err(e) => {
-                log::warn!("Failed to load vault entry for sink {}: {e}", record.id);
-                continue;
+        let secrets = if vault.enabled() {
+            match vault.get_sink(&record.id) {
+                Ok(Some(v)) => v,
+                Ok(None) => continue,
+                Err(e) => {
+                    log::warn!("Failed to load vault entry for sink {}: {e}", record.id);
+                    continue;
+                }
+            }
+        } else {
+            match mgr.get_sink_secret_fallback(&record.id).await {
+                Some(v) => v,
+                None => continue,
             }
         };
+        let id = record.id.clone();
         apply_sink_secrets(&mut record.config, &secrets);
         if let Err(e) = mgr.update_sink(record).await {
-            log::warn!("Failed to inject vault secrets into upload manager: {e}");
+            log::warn!("Failed to inject secrets into upload manager for sink {id}: {e}");
         }
     }
 }
@@ -189,7 +217,7 @@ pub async fn add_upload_sink(
     let mgr = get_mgr(&state)?;
     let vault = state.vault.clone();
     let created = mgr.add_sink(record).await?;
-    persist_sink_secrets(&vault, &created.id, &created.config);
+    persist_sink_secrets(&vault, &mgr, &created.id, &created.config).await;
     serde_json::to_value(created).map_err(|e| e.to_string())
 }
 
@@ -203,11 +231,11 @@ pub async fn update_upload_sink(
     // Empty incoming secrets mean "unchanged" — fill from vault before the
     // engine's own merge_secrets fallback runs against a disk copy that
     // never held the secret in the first place
-    fill_from_vault(&vault, &record.id, &mut record.config);
+    fill_from_vault(&vault, &mgr, &record.id, &mut record.config).await;
     let id = record.id.clone();
     let config_for_vault = record.config.clone();
     mgr.update_sink(record).await?;
-    persist_sink_secrets(&vault, &id, &config_for_vault);
+    persist_sink_secrets(&vault, &mgr, &id, &config_for_vault).await;
     Ok(())
 }
 

--- a/src-tauri/src/commands/upload_cmds.rs
+++ b/src-tauri/src/commands/upload_cmds.rs
@@ -57,9 +57,10 @@ fn extract_sink_secrets(config: &SinkConfig) -> Option<Value> {
     }
 }
 
-/// Apply secrets pulled from the keychain back onto a sink config. Empty
-/// or missing fields are silently ignored so a partial vault entry never
-/// clobbers a value the user just typed
+/// Apply secrets pulled from the keychain back onto a sink config. Only
+/// fields that are currently empty in the config are filled, so a user
+/// updating one secret does not lose another secret that was left blank
+/// (meaning "unchanged")
 fn apply_sink_secrets(config: &mut SinkConfig, secrets: &Value) {
     let obj = match secrets.as_object() {
         Some(o) => o,
@@ -73,44 +74,43 @@ fn apply_sink_secrets(config: &mut SinkConfig, secrets: &Value) {
     };
     match config {
         SinkConfig::Webdav(c) => {
-            let v = s("password");
-            if !v.is_empty() {
-                c.password = v;
+            if c.password.is_empty() {
+                let v = s("password");
+                if !v.is_empty() {
+                    c.password = v;
+                }
             }
         }
         SinkConfig::S3(c) => {
-            let v = s("secretAccessKey");
-            if !v.is_empty() {
-                c.secret_access_key = v;
+            if c.secret_access_key.is_empty() {
+                let v = s("secretAccessKey");
+                if !v.is_empty() {
+                    c.secret_access_key = v;
+                }
             }
         }
         SinkConfig::Sftp(c) => {
-            let pw = s("password");
-            if !pw.is_empty() {
-                c.password = pw;
+            if c.password.is_empty() {
+                let pw = s("password");
+                if !pw.is_empty() {
+                    c.password = pw;
+                }
             }
-            let pk = s("privateKey");
-            if !pk.is_empty() {
-                c.private_key = pk;
+            if c.private_key.is_empty() {
+                let pk = s("privateKey");
+                if !pk.is_empty() {
+                    c.private_key = pk;
+                }
             }
         }
         SinkConfig::Ftp(c) => {
-            let v = s("password");
-            if !v.is_empty() {
-                c.password = v;
+            if c.password.is_empty() {
+                let v = s("password");
+                if !v.is_empty() {
+                    c.password = v;
+                }
             }
         }
-    }
-}
-
-/// Whether the sink config currently carries any plaintext secret. Used
-/// when deciding whether to clear a stale vault entry
-fn sink_has_secrets(config: &SinkConfig) -> bool {
-    match config {
-        SinkConfig::Webdav(c) => !c.password.is_empty(),
-        SinkConfig::S3(c) => !c.secret_access_key.is_empty(),
-        SinkConfig::Sftp(c) => !c.password.is_empty() || !c.private_key.is_empty(),
-        SinkConfig::Ftp(c) => !c.password.is_empty(),
     }
 }
 
@@ -119,7 +119,7 @@ fn sink_has_secrets(config: &SinkConfig) -> bool {
 /// (treat empty as "unchanged") so editing a sink without retyping the
 /// password keeps it working
 fn fill_from_vault(vault: &VaultManager, id: &str, config: &mut SinkConfig) {
-    if !vault.enabled() || sink_has_secrets(config) {
+    if !vault.enabled() {
         return;
     }
     if let Ok(Some(secrets)) = vault.get_sink(id) {
@@ -404,10 +404,5 @@ mod tests {
         }
     }
 
-    #[test]
-    fn sink_has_secrets_detects_each_variant() {
-        assert!(!sink_has_secrets(&sftp("", "")));
-        assert!(sink_has_secrets(&sftp("p", "")));
-        assert!(sink_has_secrets(&sftp("", "k")));
-    }
+
 }

--- a/src-tauri/src/commands/vault_cmds.rs
+++ b/src-tauri/src/commands/vault_cmds.rs
@@ -1,0 +1,45 @@
+//! Tauri commands exposing the OS-keychain credential vault to the renderer
+//! Mirrors the shape of `upload_cmds` so the frontend wrapper layer stays
+//! consistent
+
+use serde::Serialize;
+use serde_json::Value;
+use tauri::State;
+
+use crate::state::AppState;
+
+#[derive(Serialize)]
+pub struct VaultStatus {
+    pub enabled: bool,
+    pub backend: &'static str,
+}
+
+#[tauri::command]
+pub fn vault_status(state: State<'_, AppState>) -> VaultStatus {
+    VaultStatus {
+        enabled: state.vault.enabled(),
+        backend: "os-keychain",
+    }
+}
+
+#[tauri::command]
+pub fn vault_put_credential(
+    state: State<'_, AppState>,
+    id: String,
+    secrets: Value,
+) -> Result<(), String> {
+    state.vault.put(&id, &secrets)
+}
+
+#[tauri::command]
+pub fn vault_get_credential(
+    state: State<'_, AppState>,
+    id: String,
+) -> Result<Option<Value>, String> {
+    state.vault.get(&id)
+}
+
+#[tauri::command]
+pub fn vault_remove_credential(state: State<'_, AppState>, id: String) -> Result<(), String> {
+    state.vault.remove(&id)
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -154,6 +154,20 @@ pub fn run() {
             upload_mgr.set_event_sink(event_sink_clone.clone());
             let upload_mgr = Some(upload_mgr);
 
+            // Inject SFTP/FTP/WebDAV/S3 secrets stored in the OS keychain
+            // back into the upload manager. The on-disk records omit them
+            // (`skip_serializing` on the protocol Configs) so without this
+            // pass the user has to re-enter every password after a restart
+            {
+                let state = app.state::<state::AppState>();
+                let vault = state.vault.clone();
+                if let Some(mgr) = upload_mgr.clone() {
+                    tauri::async_runtime::spawn(async move {
+                        commands::upload_cmds::rehydrate_upload_sinks(&mgr, &vault).await;
+                    });
+                }
+            }
+
             if should_start {
                 let config_ref = config_guard.config.lock().unwrap();
                 let config_dir = config_ref.config_dir().to_path_buf();
@@ -325,6 +339,10 @@ pub fn run() {
             commands::upload_cmds::list_upload_jobs,
             commands::upload_cmds::cancel_upload_job,
             commands::upload_cmds::clear_upload_history,
+            commands::vault_cmds::vault_status,
+            commands::vault_cmds::vault_put_credential,
+            commands::vault_cmds::vault_get_credential,
+            commands::vault_cmds::vault_remove_credential,
         ])
         .build(tauri::generate_context!())
         .expect("error while building Risuko");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -161,9 +161,9 @@ pub fn run() {
             if let Some(mgr) = upload_mgr.clone() {
                 let state = app.state::<state::AppState>();
                 let vault = state.vault.clone();
-                tauri::async_runtime::block_on(
-                    commands::upload_cmds::rehydrate_upload_sinks(&mgr, &vault)
-                );
+                tauri::async_runtime::block_on(commands::upload_cmds::rehydrate_upload_sinks(
+                    &mgr, &vault,
+                ));
             }
 
             if should_start {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -158,14 +158,12 @@ pub fn run() {
             // back into the upload manager. The on-disk records omit them
             // (`skip_serializing` on the protocol Configs) so without this
             // pass the user has to re-enter every password after a restart
-            {
+            if let Some(mgr) = upload_mgr.clone() {
                 let state = app.state::<state::AppState>();
                 let vault = state.vault.clone();
-                if let Some(mgr) = upload_mgr.clone() {
-                    tauri::async_runtime::spawn(async move {
-                        commands::upload_cmds::rehydrate_upload_sinks(&mgr, &vault).await;
-                    });
-                }
+                tauri::async_runtime::block_on(
+                    commands::upload_cmds::rehydrate_upload_sinks(&mgr, &vault)
+                );
             }
 
             if should_start {

--- a/src-tauri/src/managers/mod.rs
+++ b/src-tauri/src/managers/mod.rs
@@ -1,5 +1,6 @@
 pub mod menu;
 pub mod tray;
+pub mod vault;
 
 use tauri::Emitter;
 

--- a/src-tauri/src/managers/vault.rs
+++ b/src-tauri/src/managers/vault.rs
@@ -43,6 +43,16 @@ impl VaultManager {
         self.enabled.load(Ordering::Relaxed)
     }
 
+    /// Build a manager with a forced `enabled` flag, skipping the OS probe.
+    /// Test-only: lets unit tests in sibling modules exercise the
+    /// vault-enabled code paths without depending on a real keychain
+    #[cfg(test)]
+    pub(crate) fn for_test(enabled: bool) -> Self {
+        Self {
+            enabled: AtomicBool::new(enabled),
+        }
+    }
+
     /// Non-destructive reachability check. We only need to confirm that the
     /// keyring backend can be opened and that lookups succeed; a `NoEntry`
     /// result is a healthy outcome (backend reachable, no probe entry

--- a/src-tauri/src/managers/vault.rs
+++ b/src-tauri/src/managers/vault.rs
@@ -1,0 +1,205 @@
+//! OS-keychain-backed credential vault
+//!
+//! One keyring entry per credential id under a fixed service name; the entry
+//! value is a JSON object containing only the sensitive fields. Non-secret
+//! metadata (host, label, protocol, timestamps) stays in `user.json` so the
+//! frontend can list and match credentials without unlocking the keychain
+//!
+//! Backend: `keyring` crate — macOS Keychain, Windows Credential Manager,
+//! Linux Secret Service. When the OS backend is unavailable (headless Linux
+//! without D-Bus, sandboxed environments, etc.) `VaultManager::probe()`
+//! reports `enabled = false` and the renderer transparently falls back to
+//! storing secrets inline in `user.json` (legacy behavior)
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use serde_json::Value;
+
+const SERVICE: &str = "risuko-credentials";
+/// Separate service namespace for upload sink secrets (SFTP/FTP/WebDAV
+/// passwords, S3 secret access keys, SSH private keys). Kept distinct from
+/// the SavedCredential service so the two stores can be cleared, audited,
+/// or migrated independently
+const SINK_SERVICE: &str = "risuko-sinks";
+/// Account used by `probe()` to verify the keychain backend is reachable.
+/// Read-only — never written to, so the OS does not log a write or prompt
+/// for keychain access on every launch
+const PROBE_ACCOUNT: &str = "__probe__";
+
+pub struct VaultManager {
+    enabled: AtomicBool,
+}
+
+impl VaultManager {
+    pub fn new() -> Self {
+        let mgr = Self {
+            enabled: AtomicBool::new(false),
+        };
+        mgr.probe();
+        mgr
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.enabled.load(Ordering::Relaxed)
+    }
+
+    /// Non-destructive reachability check. We only need to confirm that the
+    /// keyring backend can be opened and that lookups succeed; a `NoEntry`
+    /// result is a healthy outcome (backend reachable, no probe entry
+    /// stored). This avoids the spurious write-then-delete cycle the
+    /// previous implementation performed on every launch, which could
+    /// trigger OS keychain access prompts and audit-log noise
+    fn probe(&self) {
+        let ok = match keyring::Entry::new(SERVICE, PROBE_ACCOUNT) {
+            Ok(entry) => match entry.get_password() {
+                Ok(_) | Err(keyring::Error::NoEntry) => true,
+                Err(_) => false,
+            },
+            Err(_) => false,
+        };
+        self.enabled.store(ok, Ordering::Relaxed);
+        if ok {
+            log::info!("Credential vault: OS keychain available");
+        } else {
+            log::warn!("Credential vault: OS keychain unavailable, falling back to plaintext");
+        }
+    }
+
+    /// Store the secret JSON object for the given credential id.
+    pub fn put(&self, id: &str, secrets: &Value) -> Result<(), String> {
+        self.put_at(SERVICE, id, secrets)
+    }
+
+    /// Retrieve the secret JSON object for the given credential id.
+    /// Returns `Ok(None)` when the entry does not exist
+    pub fn get(&self, id: &str) -> Result<Option<Value>, String> {
+        self.get_at(SERVICE, id)
+    }
+
+    /// Best-effort delete; missing entries are not an error
+    pub fn remove(&self, id: &str) -> Result<(), String> {
+        self.remove_at(SERVICE, id)
+    }
+
+    /// Store secrets for an upload sink (separate keychain namespace)
+    pub fn put_sink(&self, id: &str, secrets: &Value) -> Result<(), String> {
+        self.put_at(SINK_SERVICE, id, secrets)
+    }
+
+    /// Retrieve secrets for an upload sink
+    pub fn get_sink(&self, id: &str) -> Result<Option<Value>, String> {
+        self.get_at(SINK_SERVICE, id)
+    }
+
+    /// Best-effort delete of an upload sink's secrets
+    pub fn remove_sink(&self, id: &str) -> Result<(), String> {
+        self.remove_at(SINK_SERVICE, id)
+    }
+
+    fn put_at(&self, service: &str, account: &str, secrets: &Value) -> Result<(), String> {
+        if !self.enabled() {
+            return Err("vault not available".to_string());
+        }
+        let json = serde_json::to_string(secrets).map_err(|e| e.to_string())?;
+        let entry = keyring::Entry::new(service, account).map_err(|e| e.to_string())?;
+        entry.set_password(&json).map_err(|e| e.to_string())
+    }
+
+    fn get_at(&self, service: &str, account: &str) -> Result<Option<Value>, String> {
+        if !self.enabled() {
+            return Ok(None);
+        }
+        let entry = keyring::Entry::new(service, account).map_err(|e| e.to_string())?;
+        match entry.get_password() {
+            Ok(json) => {
+                let v: Value = serde_json::from_str(&json).map_err(|e| e.to_string())?;
+                Ok(Some(v))
+            }
+            Err(keyring::Error::NoEntry) => Ok(None),
+            Err(e) => Err(e.to_string()),
+        }
+    }
+
+    fn remove_at(&self, service: &str, account: &str) -> Result<(), String> {
+        if !self.enabled() {
+            return Ok(());
+        }
+        let entry = keyring::Entry::new(service, account).map_err(|e| e.to_string())?;
+        match entry.delete_credential() {
+            Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
+            Err(e) => Err(e.to_string()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// Build a `VaultManager` with a forced `enabled` state, bypassing the
+    /// real probe so unit tests can exercise the disabled code paths
+    /// without depending on the host's OS keychain
+    fn manager_with(enabled: bool) -> VaultManager {
+        VaultManager {
+            enabled: AtomicBool::new(enabled),
+        }
+    }
+
+    #[test]
+    fn disabled_put_is_err() {
+        let m = manager_with(false);
+        assert!(!m.enabled());
+        let err = m.put("any-id", &json!({"ftpPasswd": "x"})).unwrap_err();
+        assert!(err.contains("not available"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn disabled_get_returns_none() {
+        let m = manager_with(false);
+        assert_eq!(m.get("any-id").unwrap(), None);
+    }
+
+    #[test]
+    fn disabled_remove_is_ok() {
+        let m = manager_with(false);
+        // Should silently succeed so callers can blindly remove on cleanup
+        m.remove("any-id").unwrap();
+    }
+
+    /// Integration test against the real OS keychain. Skipped by default
+    /// because CI hosts and headless Linux environments may lack a usable
+    /// backend; opt in by setting `RISUKO_VAULT_INTEGRATION_TEST=1`
+    #[test]
+    fn enabled_round_trip_real_keychain() {
+        if std::env::var("RISUKO_VAULT_INTEGRATION_TEST")
+            .ok()
+            .as_deref()
+            != Some("1")
+        {
+            return;
+        }
+        let m = VaultManager::new();
+        if !m.enabled() {
+            // No usable backend on this host; treat as a skip
+            return;
+        }
+
+        let id = format!("risuko-test-{}", std::process::id());
+        let secrets = json!({
+            "ftpUser": "alice",
+            "ftpPasswd": "s3cret!",
+            "authorization": "Bearer abc",
+        });
+
+        m.put(&id, &secrets).expect("put");
+        let fetched = m.get(&id).expect("get").expect("entry exists");
+        assert_eq!(fetched, secrets);
+
+        m.remove(&id).expect("remove");
+        assert_eq!(m.get(&id).expect("get after remove"), None);
+
+        // Removing a missing entry must remain a no-op
+        m.remove(&id).expect("idempotent remove");
+    }
+}

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -7,12 +7,15 @@ use risuko_engine::engine::rss::RssManager;
 use risuko_engine::engine::upload::UploadSinkManager;
 use risuko_engine::traits::StorageBackend;
 
+use crate::managers::vault::VaultManager;
+
 pub struct AppState {
     pub config: Mutex<ConfigManager>,
     pub engine_running: Mutex<bool>,
     pub is_quitting: AtomicBool,
     pub rss: Mutex<Option<Arc<RssManager>>>,
     pub upload_sinks: Mutex<Option<Arc<UploadSinkManager>>>,
+    pub vault: Arc<VaultManager>,
     pub log_dir: PathBuf,
     /// Keeps the file logger alive; dropped when AppState is dropped.
     pub _log_guard: Option<tracing_appender::non_blocking::WorkerGuard>,
@@ -40,6 +43,7 @@ impl AppState {
             is_quitting: AtomicBool::new(false),
             rss: Mutex::new(Some(Arc::new(rss_manager))),
             upload_sinks: Mutex::new(Some(Arc::new(upload_manager))),
+            vault: Arc::new(VaultManager::new()),
             log_dir,
             _log_guard: Some(log_guard),
         })

--- a/src/renderer/api/Api.ts
+++ b/src/renderer/api/Api.ts
@@ -648,4 +648,24 @@ export default class Api {
 	clearUploadHistory() {
 		return invoke("clear_upload_history");
 	}
+
+	// -- Credential vault (OS keychain) --
+
+	vaultStatus() {
+		return invoke<{ enabled: boolean; backend: string }>("vault_status");
+	}
+
+	vaultPutCredential(id: string, secrets: Record<string, string | undefined>) {
+		return invoke("vault_put_credential", { id, secrets });
+	}
+
+	vaultGetCredential(id: string) {
+		return invoke<Record<string, string> | null>("vault_get_credential", {
+			id,
+		});
+	}
+
+	vaultRemoveCredential(id: string) {
+		return invoke("vault_remove_credential", { id });
+	}
 }

--- a/src/renderer/components/Preference/CloudSinks.vue
+++ b/src/renderer/components/Preference/CloudSinks.vue
@@ -1291,6 +1291,7 @@ export default defineComponent({
 				return;
 			}
 			this.saving = true;
+			let savedSink: UploadSinkRecord | null = null;
 			try {
 				const config = this.buildConfig();
 				if (this.editingId) {
@@ -1308,7 +1309,7 @@ export default defineComponent({
 						moveTarget: this.form.moveTarget || null,
 					};
 					await this.store.updateSink(updated);
-					await this.syncCredential(updated);
+					savedSink = updated;
 				} else {
 					const created = await this.store.addSink({
 						label: this.form.label.trim(),
@@ -1316,14 +1317,27 @@ export default defineComponent({
 						postAction: this.form.postAction,
 						moveTarget: this.form.moveTarget || null,
 					});
-					await this.syncCredential(created);
+					savedSink = created;
 				}
 				this.dialogOpen = false;
 			} catch (e) {
 				this.dialogError = String((e as Error)?.message || e);
-			} finally {
 				this.saving = false;
+				return;
 			}
+
+			if (savedSink) {
+				try {
+					await this.syncCredential(savedSink);
+				} catch (e) {
+					this.$msg.error(
+						this.$t("cloudSinks.credentialSyncFailed") +
+						": " +
+						String((e as Error)?.message || e),
+					);
+				}
+			}
+			this.saving = false;
 		},
 		askRemove(sink: UploadSinkRecord) {
 			this.removingSink = sink;

--- a/src/renderer/components/Preference/CloudSinks.vue
+++ b/src/renderer/components/Preference/CloudSinks.vue
@@ -789,6 +789,7 @@
 </template>
 
 <script lang="ts">
+import type { SavedCredential } from "@shared/types/credential";
 import type {
 	SinkConfig,
 	UploadJob,
@@ -846,6 +847,7 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "@/components/ui/select";
+import { usePreferenceStore } from "@/store/preference";
 import { useUploadSinkStore } from "@/store/uploadSink";
 
 interface FormState {
@@ -1306,13 +1308,15 @@ export default defineComponent({
 						moveTarget: this.form.moveTarget || null,
 					};
 					await this.store.updateSink(updated);
+					await this.syncCredential(updated);
 				} else {
-					await this.store.addSink({
+					const created = await this.store.addSink({
 						label: this.form.label.trim(),
 						config,
 						postAction: this.form.postAction,
 						moveTarget: this.form.moveTarget || null,
 					});
+					await this.syncCredential(created);
 				}
 				this.dialogOpen = false;
 			} catch (e) {
@@ -1333,6 +1337,7 @@ export default defineComponent({
 			this.removingSink = null;
 			try {
 				await this.store.removeSink(id);
+				await usePreferenceStore().removeCredential(id);
 				toast.success(this.$t("cloudSinks.removed", { label }) as string);
 			} catch (e) {
 				toast.error(String((e as Error)?.message || e));
@@ -1353,6 +1358,81 @@ export default defineComponent({
 		},
 		async onSetDefault(id: string) {
 			await this.store.setDefaultSink(id);
+		},
+		mapSinkToCredential(record: UploadSinkRecord): SavedCredential | null {
+			const now = Date.now();
+			const base = {
+				id: record.id,
+				label: record.label,
+				createdAt: now,
+				lastUsedAt: now,
+			};
+			const c = record.config;
+			if (c.kind === "sftp") {
+				return {
+					...base,
+					host: c.host,
+					protocol: "sftp",
+					ftpUser: c.username,
+					ftpPasswd: c.password || "",
+					sftpPrivateKey: c.privateKey || "",
+					sftpPrivateKeyContent: c.privateKey || "",
+				} as SavedCredential;
+			}
+			if (c.kind === "ftp") {
+				return {
+					...base,
+					host: c.host,
+					protocol: "ftp",
+					ftpUser: c.username || "",
+					ftpPasswd: c.password || "",
+				} as SavedCredential;
+			}
+			return null;
+		},
+		async syncCredential(record: UploadSinkRecord) {
+			const preferenceStore = usePreferenceStore();
+			const mapped = this.mapSinkToCredential(record);
+			if (!mapped) {
+				await preferenceStore.removeCredential(record.id);
+				return;
+			}
+			const existing = preferenceStore
+				.getSavedCredentials()
+				.find((c: SavedCredential) => c.id === record.id);
+			if (existing) {
+				const credential: SavedCredential = { ...existing, ...mapped };
+				const secretFields: (keyof SavedCredential)[] = [
+					"authorization",
+					"cookie",
+					"ftpUser",
+					"ftpPasswd",
+					"sftpPrivateKey",
+					"sftpPrivateKeyContent",
+					"sftpKeyPassphrase",
+					"allProxy",
+				];
+				const mappedRec = mapped as unknown as Record<
+					string,
+					string | undefined
+				>;
+				const existingRec = existing as unknown as Record<
+					string,
+					string | undefined
+				>;
+				const credentialRec = credential as unknown as Record<
+					string,
+					string | undefined
+				>;
+				for (const key of secretFields) {
+					if (!mappedRec[key] && existingRec[key]) {
+						credentialRec[key] = existingRec[key];
+					}
+				}
+				await preferenceStore.saveCredential(credential);
+			} else {
+				await preferenceStore.saveCredential(mapped);
+			}
 		},
 		jobStatusLabel(status: UploadJobStatus): string {
 			const map: Record<UploadJobStatus, string> = {

--- a/src/renderer/components/Preference/CloudSinks.vue
+++ b/src/renderer/components/Preference/CloudSinks.vue
@@ -790,6 +790,7 @@
 
 <script lang="ts">
 import type { SavedCredential } from "@shared/types/credential";
+import { CREDENTIAL_SECRET_FIELDS } from "@shared/types/credential";
 import type {
 	SinkConfig,
 	UploadJob,
@@ -1332,8 +1333,8 @@ export default defineComponent({
 				} catch (e) {
 					this.$msg.error(
 						this.$t("cloudSinks.credentialSyncFailed") +
-						": " +
-						String((e as Error)?.message || e),
+							": " +
+							String((e as Error)?.message || e),
 					);
 				}
 			}
@@ -1361,7 +1362,7 @@ export default defineComponent({
 			} catch (e) {
 				const msg = String((e as Error)?.message || e);
 				toast.error(msg);
-				console.warn("Failed to remove credential for sink", id, msg);
+				logger.warn("[Risuko] Failed to remove credential for sink", id, msg);
 			}
 		},
 		async onTest(id: string) {
@@ -1381,12 +1382,19 @@ export default defineComponent({
 			await this.store.setDefaultSink(id);
 		},
 		mapSinkToCredential(record: UploadSinkRecord): SavedCredential | null {
-			const now = Date.now();
-			const base = {
+			// Timestamps intentionally omitted here: `syncCredential` assigns
+			// `createdAt`/`lastUsedAt` only when the credential is new, so
+			// edits (renames, host changes, password updates) preserve the
+			// original timestamps instead of resetting them on every sync.
+			//
+			// Secret fields owned by this protocol are always included
+			// (even when empty) so the merge loop in `syncCredential` can
+			// distinguish "untouched" (key absent) from "explicit clear"
+			// (key === ""), allowing the user to actually wipe a stored
+			// secret by saving a sink with the field cleared
+			const base: Partial<SavedCredential> = {
 				id: record.id,
 				label: record.label,
-				createdAt: now,
-				lastUsedAt: now,
 			};
 			const c = record.config;
 			if (c.kind === "sftp") {
@@ -1395,13 +1403,9 @@ export default defineComponent({
 					host: c.host,
 					protocol: "sftp",
 					ftpUser: c.username,
-					...(c.password ? { ftpPasswd: c.password } : {}),
-					...(c.privateKey
-						? {
-								sftpPrivateKey: c.privateKey,
-								sftpPrivateKeyContent: c.privateKey,
-							}
-						: {}),
+					ftpPasswd: c.password ?? "",
+					sftpPrivateKey: c.privateKey ?? "",
+					sftpPrivateKeyContent: c.privateKey ?? "",
 				} as SavedCredential;
 			}
 			if (c.kind === "ftp") {
@@ -1410,7 +1414,7 @@ export default defineComponent({
 					host: c.host,
 					protocol: "ftp",
 					ftpUser: c.username || "",
-					...(c.password ? { ftpPasswd: c.password } : {}),
+					ftpPasswd: c.password ?? "",
 				} as SavedCredential;
 			}
 			return null;
@@ -1426,17 +1430,13 @@ export default defineComponent({
 				.getSavedCredentials()
 				.find((c: SavedCredential) => c.id === record.id);
 			if (existing) {
-				const credential: SavedCredential = { ...existing, ...mapped };
-				const secretFields: (keyof SavedCredential)[] = [
-					"authorization",
-					"cookie",
-					"ftpUser",
-					"ftpPasswd",
-					"sftpPrivateKey",
-					"sftpPrivateKeyContent",
-					"sftpKeyPassphrase",
-					"allProxy",
-				];
+				const credential: SavedCredential = {
+					...existing,
+					...mapped,
+					// Preserve original timestamps on edits
+					createdAt: existing.createdAt,
+					lastUsedAt: existing.lastUsedAt,
+				};
 				const mappedRec = mapped as unknown as Record<
 					string,
 					string | undefined
@@ -1449,14 +1449,27 @@ export default defineComponent({
 					string,
 					string | undefined
 				>;
-				for (const key of secretFields) {
-					if (!mappedRec[key] && existingRec[key]) {
-						credentialRec[key] = existingRec[key];
+				// Distinguish "untouched" (key absent on mapped) from
+				// "explicit clear" (key present with empty string). Treating
+				// any falsy value as "keep existing" — the previous behavior
+				// — silently reverted user-initiated clears
+				for (const key of CREDENTIAL_SECRET_FIELDS) {
+					if (!Object.hasOwn(mappedRec, key)) {
+						if (existingRec[key] !== undefined) {
+							credentialRec[key] = existingRec[key];
+						}
+					} else {
+						credentialRec[key] = mappedRec[key];
 					}
 				}
 				await preferenceStore.saveCredential(credential);
 			} else {
-				await preferenceStore.saveCredential(mapped);
+				const now = Date.now();
+				await preferenceStore.saveCredential({
+					...mapped,
+					createdAt: now,
+					lastUsedAt: now,
+				});
 			}
 		},
 		jobStatusLabel(status: UploadJobStatus): string {

--- a/src/renderer/components/Preference/CloudSinks.vue
+++ b/src/renderer/components/Preference/CloudSinks.vue
@@ -1351,10 +1351,17 @@ export default defineComponent({
 			this.removingSink = null;
 			try {
 				await this.store.removeSink(id);
-				await usePreferenceStore().removeCredential(id);
-				toast.success(this.$t("cloudSinks.removed", { label }) as string);
 			} catch (e) {
 				toast.error(String((e as Error)?.message || e));
+				return;
+			}
+			toast.success(this.$t("cloudSinks.removed", { label }) as string);
+			try {
+				await usePreferenceStore().removeCredential(id);
+			} catch (e) {
+				const msg = String((e as Error)?.message || e);
+				toast.error(msg);
+				console.warn("Failed to remove credential for sink", id, msg);
 			}
 		},
 		async onTest(id: string) {
@@ -1388,9 +1395,13 @@ export default defineComponent({
 					host: c.host,
 					protocol: "sftp",
 					ftpUser: c.username,
-					ftpPasswd: c.password || "",
-					sftpPrivateKey: c.privateKey || "",
-					sftpPrivateKeyContent: c.privateKey || "",
+					...(c.password ? { ftpPasswd: c.password } : {}),
+					...(c.privateKey
+						? {
+								sftpPrivateKey: c.privateKey,
+								sftpPrivateKeyContent: c.privateKey,
+							}
+						: {}),
 				} as SavedCredential;
 			}
 			if (c.kind === "ftp") {
@@ -1399,7 +1410,7 @@ export default defineComponent({
 					host: c.host,
 					protocol: "ftp",
 					ftpUser: c.username || "",
-					ftpPasswd: c.password || "",
+					...(c.password ? { ftpPasswd: c.password } : {}),
 				} as SavedCredential;
 			}
 			return null;

--- a/src/renderer/components/Preference/CredentialManager.vue
+++ b/src/renderer/components/Preference/CredentialManager.vue
@@ -16,6 +16,13 @@
           <span v-if="cred.protocol" class="credential-manager-item-protocol">
             {{ cred.protocol }}
           </span>
+          <span
+            v-if="cred.vaulted"
+            class="credential-manager-item-vaulted"
+            :title="$t('preferences.credential-encrypted-badge')"
+          >
+            <ShieldCheck :size="11" />
+          </span>
           <span v-if="cred.host && cred.label" class="credential-manager-item-host">
             {{ cred.host }}
           </span>
@@ -35,20 +42,34 @@
         </div>
       </li>
     </ul>
+    <div
+      class="credential-manager-status"
+      :class="{ 'credential-manager-status--off': !vaultEnabled }"
+      :title="vaultEnabled ? '' : $t('preferences.credential-vault-unavailable')"
+    >
+      <ShieldCheck v-if="vaultEnabled" :size="12" />
+      <ShieldOff v-else :size="12" />
+      <span>
+        {{ vaultEnabled ? $t('preferences.vault-enabled') : $t('preferences.vault-disabled') }}
+      </span>
+    </div>
   </div>
 </template>
 
 <script lang="ts">
 import type { SavedCredential } from "@shared/types/credential";
-import { Trash2 } from "lucide-vue-next";
+import { ShieldCheck, ShieldOff, Trash2 } from "lucide-vue-next";
 import { usePreferenceStore } from "@/store/preference";
 
 export default {
 	name: "mo-credential-manager",
-	components: { Trash2 },
+	components: { ShieldCheck, ShieldOff, Trash2 },
 	computed: {
 		credentials(): SavedCredential[] {
 			return usePreferenceStore().getSavedCredentials();
+		},
+		vaultEnabled(): boolean {
+			return usePreferenceStore().vaultEnabled;
 		},
 	},
 	methods: {

--- a/src/renderer/components/Task/CredentialSuggest.vue
+++ b/src/renderer/components/Task/CredentialSuggest.vue
@@ -124,12 +124,17 @@ export default {
 	},
 	methods: {
 		async handleApply(credential: SavedCredential) {
-			await applyCredentialToForm(this.form, credential);
-			usePreferenceStore().updateCredentialLastUsed(credential.id);
-			this.$msg.success({
-				message: this.$t("task.credential-applied"),
-				duration: 2000,
-			});
+			try {
+				await applyCredentialToForm(this.form, credential);
+				usePreferenceStore().updateCredentialLastUsed(credential.id);
+				this.$msg.success({
+					message: this.$t("task.credential-applied"),
+					duration: 2000,
+				});
+			} catch (err) {
+				console.error("Failed to apply credential:", err);
+				this.$msg.error(this.$t("task.credential-apply-failed"));
+			}
 		},
 		credentialDisplayName(cred: SavedCredential): string {
 			if (cred.label) {

--- a/src/renderer/components/Task/CredentialSuggest.vue
+++ b/src/renderer/components/Task/CredentialSuggest.vue
@@ -54,6 +54,7 @@
 
 <script lang="ts">
 import type { SavedCredential } from "@shared/types/credential";
+import logger from "@shared/utils/logger";
 import { ChevronDown, KeyRound } from "lucide-vue-next";
 import {
 	DropdownMenu,
@@ -132,7 +133,7 @@ export default {
 					duration: 2000,
 				});
 			} catch (err) {
-				console.error("Failed to apply credential:", err);
+				logger.error("[Risuko] Failed to apply credential:", err);
 				this.$msg.error(this.$t("task.credential-apply-failed"));
 			}
 		},

--- a/src/renderer/components/Task/CredentialSuggest.vue
+++ b/src/renderer/components/Task/CredentialSuggest.vue
@@ -123,8 +123,8 @@ export default {
 		},
 	},
 	methods: {
-		handleApply(credential: SavedCredential) {
-			applyCredentialToForm(this.form, credential);
+		async handleApply(credential: SavedCredential) {
+			await applyCredentialToForm(this.form, credential);
 			usePreferenceStore().updateCredentialLastUsed(credential.id);
 			this.$msg.success({
 				message: this.$t("task.credential-applied"),

--- a/src/renderer/store/batchQueue.ts
+++ b/src/renderer/store/batchQueue.ts
@@ -1,17 +1,17 @@
 import { SELECTED_ALL_FILES } from "@shared/constants";
 
-export type BatchItemKind = "torrent" | "uri" | "magnet";
+type BatchItemKind = "torrent" | "uri" | "magnet";
 
-export type BatchItemStatus = "queued" | "submitting" | "success" | "failed";
+type BatchItemStatus = "queued" | "submitting" | "success" | "failed";
 
-export type BatchItemResolveState =
+type BatchItemResolveState =
 	| "idle"
 	| "loading"
 	| "ready"
 	| "error"
 	| "preview-disabled";
 
-export interface BatchItemFileSummary {
+interface BatchItemFileSummary {
 	idx: number;
 	name: string;
 	path: string;

--- a/src/renderer/store/preference.ts
+++ b/src/renderer/store/preference.ts
@@ -4,7 +4,10 @@ import {
 	MAX_NUM_OF_SAVED_CREDENTIALS,
 } from "@shared/constants";
 import type { AppConfig } from "@shared/types/config";
-import type { SavedCredential } from "@shared/types/credential";
+import {
+	CREDENTIAL_SECRET_FIELDS,
+	type SavedCredential,
+} from "@shared/types/credential";
 import {
 	changeKeysToCamelCase,
 	changeKeysToKebabCase,
@@ -25,6 +28,7 @@ import { useTaskStore } from "@/store/task";
 export const usePreferenceStore = defineStore("preference", {
 	state: () => ({
 		engineMode: "MAX",
+		vaultEnabled: false,
 		config: {
 			locale: "en-US",
 		} as AppConfig,
@@ -39,6 +43,9 @@ export const usePreferenceStore = defineStore("preference", {
 			try {
 				const config = await api.fetchPreference();
 				this.updatePreference(config);
+				// Probe the vault before returning so callers awaiting fetchPreference
+				// observe the correct vaultEnabled state on the very next save
+				await this.fetchVaultStatus();
 				return config;
 			} catch (err: unknown) {
 				logger.warn("[Risuko] fetchPreference failed:", (err as Error).message);
@@ -135,29 +142,137 @@ export const usePreferenceStore = defineStore("preference", {
 					(b.lastUsedAt || 0) - (a.lastUsedAt || 0),
 			);
 		},
-		saveCredential(credential: SavedCredential) {
+		async fetchVaultStatus() {
+			try {
+				const { enabled } = await api.vaultStatus();
+				this.vaultEnabled = enabled;
+			} catch (err) {
+				logger.warn("[Risuko] vaultStatus failed:", (err as Error).message);
+				this.vaultEnabled = false;
+			}
+		},
+		/**
+		 * Split a credential into (metadata, secrets). Used when persisting:
+		 * metadata is stored inline in `user.json`, secrets go to the OS
+		 * keychain when the vault is available
+		 */
+		_splitCredentialSecrets(credential: SavedCredential): {
+			meta: SavedCredential;
+			secrets: Record<string, string>;
+		} {
+			const meta: SavedCredential = { ...credential };
+			const secrets: Record<string, string> = {};
+			for (const key of CREDENTIAL_SECRET_FIELDS) {
+				const val = meta[key];
+				if (typeof val === "string" && val.length > 0) {
+					secrets[key] = val;
+				}
+				meta[key] = undefined;
+			}
+			return { meta, secrets };
+		},
+		async saveCredential(credential: SavedCredential) {
 			const { savedCredentials = [] } = this.config;
+			let toStore: SavedCredential = credential;
+
+			if (this.vaultEnabled) {
+				const { meta, secrets } = this._splitCredentialSecrets(credential);
+				try {
+					if (Object.keys(secrets).length > 0) {
+						await api.vaultPutCredential(credential.id, secrets);
+					} else {
+						// No secret material — drop any prior vault entry
+						await api.vaultRemoveCredential(credential.id);
+					}
+					meta.vaulted = true;
+					toStore = meta;
+				} catch (err) {
+					logger.warn(
+						"[Risuko] vaultPutCredential failed, falling back to inline:",
+						(err as Error).message,
+					);
+					// Best-effort cleanup of any stale vault entry so that the
+					// inline fallback isn't silently shadowed by older keychain
+					// secrets the next time the credential is loaded
+					try {
+						await api.vaultRemoveCredential(credential.id);
+					} catch {
+						// already logged above; nothing else we can do here
+					}
+					toStore = { ...credential, vaulted: false };
+				}
+			}
+
 			const idx = savedCredentials.findIndex(
-				(c: SavedCredential) => c.id === credential.id,
+				(c: SavedCredential) => c.id === toStore.id,
 			);
 			let updated: SavedCredential[];
 			if (idx >= 0) {
 				updated = [...savedCredentials];
-				updated[idx] = credential;
+				updated[idx] = toStore;
 			} else {
-				updated = [credential, ...savedCredentials];
+				updated = [toStore, ...savedCredentials];
 				if (updated.length > MAX_NUM_OF_SAVED_CREDENTIALS) {
 					updated = updated.slice(0, MAX_NUM_OF_SAVED_CREDENTIALS);
 				}
 			}
-			this.save({ savedCredentials: updated });
+			await this.save({ savedCredentials: updated });
 		},
-		removeCredential(id: string) {
+		async removeCredential(id: string) {
 			const { savedCredentials = [] } = this.config;
+			const target = savedCredentials.find((c: SavedCredential) => c.id === id);
+			if (target?.vaulted) {
+				try {
+					await api.vaultRemoveCredential(id);
+				} catch (err) {
+					logger.warn(
+						"[Risuko] vaultRemoveCredential failed:",
+						(err as Error).message,
+					);
+				}
+			}
 			const updated = savedCredentials.filter(
 				(c: SavedCredential) => c.id !== id,
 			);
-			this.save({ savedCredentials: updated });
+			await this.save({ savedCredentials: updated });
+		},
+		/**
+		 * Lazily hydrate the secret fields of a vaulted credential from the
+		 * OS keychain. Returns a shallow copy with secrets populated; the
+		 * returned object is NOT cached in the store
+		 */
+		async loadCredentialSecrets(
+			credential: SavedCredential,
+		): Promise<SavedCredential> {
+			if (!credential.vaulted) {
+				return credential;
+			}
+			if (!this.vaultEnabled) {
+				// Stored credential expects the OS keychain but the backend is
+				// unreachable in this session. Surface the issue so the user
+				// understands why the form fields stay blank instead of failing
+				// silently mid-download
+				logger.warn(
+					`[Risuko] credential ${credential.id} is vaulted but the OS keychain is unavailable; secrets will not be applied.`,
+				);
+				return credential;
+			}
+			try {
+				const secrets = await api.vaultGetCredential(credential.id);
+				if (!secrets) {
+					logger.warn(
+						`[Risuko] credential ${credential.id} marked vaulted but no entry in OS keychain.`,
+					);
+					return credential;
+				}
+				return { ...credential, ...secrets };
+			} catch (err) {
+				logger.warn(
+					"[Risuko] vaultGetCredential failed:",
+					(err as Error).message,
+				);
+				return credential;
+			}
 		},
 		updateCredentialLastUsed(id: string) {
 			const { savedCredentials = [] } = this.config;

--- a/src/renderer/store/preference.ts
+++ b/src/renderer/store/preference.ts
@@ -180,11 +180,12 @@ export const usePreferenceStore = defineStore("preference", {
 				try {
 					if (Object.keys(secrets).length > 0) {
 						await api.vaultPutCredential(credential.id, secrets);
+						meta.vaulted = true;
 					} else {
 						// No secret material — drop any prior vault entry
 						await api.vaultRemoveCredential(credential.id);
+						meta.vaulted = false;
 					}
-					meta.vaulted = true;
 					toStore = meta;
 				} catch (err) {
 					logger.warn(

--- a/src/renderer/store/preference.ts
+++ b/src/renderer/store/preference.ts
@@ -176,20 +176,36 @@ export const usePreferenceStore = defineStore("preference", {
 			let toStore: SavedCredential = credential;
 
 			if (this.vaultEnabled) {
+				// Derive `wasVaulted` from the *persisted* record, not from
+				// the incoming credential. Callers may construct a fresh
+				// SavedCredential without the `vaulted` flag (e.g. sink-form
+				// sync paths that don't carry vault metadata); trusting the
+				// incoming flag would silently drop the OS-keychain entry on
+				// every metadata-only save
+				const persisted = savedCredentials.find(
+					(c: SavedCredential) => c.id === credential.id,
+				);
+				const wasVaulted = !!persisted?.vaulted;
 				const { meta, secrets } = this._splitCredentialSecrets(credential);
+				// Strip the transient flag before persistence
+				const explicitClear = !!meta.clearVault;
+				delete meta.clearVault;
 				try {
 					if (Object.keys(secrets).length > 0) {
 						await api.vaultPutCredential(credential.id, secrets);
 						meta.vaulted = true;
-					} else if (!meta.vaulted) {
-						// No secret material and not previously vaulted — safe to
-						// remove any stale vault entry
+					} else if (explicitClear) {
+						// User asked to wipe the keychain entry
 						await api.vaultRemoveCredential(credential.id);
 						meta.vaulted = false;
+					} else if (wasVaulted) {
+						// Metadata-only edit on a vaulted credential — leave
+						// the existing keychain entry alone
+						meta.vaulted = true;
 					} else {
-						// Previously vaulted but secrets payload is empty:
-						// treat as a metadata-only edit and preserve the vault entry
-						// meta.vaulted stays true
+						// No prior vault entry and no secret material — nothing
+						// to do, just record the inline (empty) state
+						meta.vaulted = false;
 					}
 					toStore = meta;
 				} catch (err) {
@@ -206,7 +222,12 @@ export const usePreferenceStore = defineStore("preference", {
 						// already logged above; nothing else we can do here
 					}
 					toStore = { ...credential, vaulted: false };
+					delete (toStore as SavedCredential).clearVault;
 				}
+			} else if (credential.clearVault) {
+				// Strip the transient flag even when the vault isn't in use
+				toStore = { ...credential };
+				delete (toStore as SavedCredential).clearVault;
 			}
 
 			const idx = savedCredentials.findIndex(

--- a/src/renderer/store/preference.ts
+++ b/src/renderer/store/preference.ts
@@ -181,10 +181,15 @@ export const usePreferenceStore = defineStore("preference", {
 					if (Object.keys(secrets).length > 0) {
 						await api.vaultPutCredential(credential.id, secrets);
 						meta.vaulted = true;
-					} else {
-						// No secret material — drop any prior vault entry
+					} else if (!meta.vaulted) {
+						// No secret material and not previously vaulted — safe to
+						// remove any stale vault entry
 						await api.vaultRemoveCredential(credential.id);
 						meta.vaulted = false;
+					} else {
+						// Previously vaulted but secrets payload is empty:
+						// treat as a metadata-only edit and preserve the vault entry
+						// meta.vaulted stays true
 					}
 					toStore = meta;
 				} catch (err) {

--- a/src/renderer/styles/components/preferences.css
+++ b/src/renderer/styles/components/preferences.css
@@ -426,4 +426,34 @@
 		color: #ef4444;
 		background: rgba(239, 68, 68, 0.08);
 	}
+	.credential-manager-item-vaulted {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		padding: 1px 5px;
+		border-radius: 3px;
+		background: rgba(34, 197, 94, 0.12);
+		color: #16a34a;
+		flex-shrink: 0;
+	}
+	.dark .credential-manager-item-vaulted {
+		background: rgba(34, 197, 94, 0.18);
+		color: #4ade80;
+	}
+	.credential-manager-status {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		margin-top: 10px;
+		padding-top: 10px;
+		border-top: 1px solid var(--border);
+		font-size: 11px;
+		color: var(--muted-foreground);
+	}
+	.credential-manager-status--off {
+		color: #d97706;
+	}
+	.dark .credential-manager-status--off {
+		color: #fbbf24;
+	}
 }

--- a/src/renderer/utils/task.ts
+++ b/src/renderer/utils/task.ts
@@ -275,12 +275,19 @@ export function extractProtocolFromUri(uri: string): string | undefined {
 	return "http";
 }
 
-export function applyCredentialToForm(
+export async function applyCredentialToForm(
 	form: TaskForm,
 	credential: SavedCredential,
-): void {
+): Promise<void> {
+	let source: SavedCredential = credential;
+	if (credential.vaulted) {
+		// Lazily hydrate secrets from the OS keychain. Imported inline to
+		// avoid a top-level cycle between utils and the preference store.
+		const { usePreferenceStore } = await import("@/store/preference");
+		source = await usePreferenceStore().loadCredentialSecrets(credential);
+	}
 	for (const key of AUTH_FIELDS) {
-		const val = credential[key];
+		const val = source[key];
 		if (typeof val === "string" && val.trim()) {
 			form[key] = val;
 		}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -206,23 +206,6 @@ export const TRAY_CANVAS_CONFIG = {
 	TEXT_FONT_SIZE: 8,
 };
 
-const COMMON_RESOURCE_TAGS = [
-	"http://",
-	"https://",
-	"ftp://",
-	"ftps://",
-	"sftp://",
-	"file://",
-	"magnet:",
-	"ed2k://",
-];
-const THUNDER_RESOURCE_TAGS = ["thunder://"];
-
-export const RESOURCE_TAGS = [
-	...COMMON_RESOURCE_TAGS,
-	...THUNDER_RESOURCE_TAGS,
-];
-
 export const SUPPORT_RTL_LOCALES = [
 	/* 'العربية', Arabic */
 	"ar",

--- a/src/shared/locales/en-US/cloudSinks.ts
+++ b/src/shared/locales/en-US/cloudSinks.ts
@@ -139,6 +139,7 @@ export default {
 	confirmRemoveRule: "This rule will be deleted. The sinks remain.",
 	errRuleSinkRequired: "Pick a sink to route to.",
 	errRuleSizeRange: "Min size must be less than or equal to max size.",
+	credentialSyncFailed: "Credential sync failed",
 	cat_music: "Music",
 	cat_video: "Video",
 	cat_image: "Image",

--- a/src/shared/locales/en-US/preferences.ts
+++ b/src/shared/locales/en-US/preferences.ts
@@ -213,4 +213,9 @@ export default {
 	"credential-delete": "Delete Credential",
 	"credential-delete-confirm":
 		"Are you sure you want to delete this saved credential?",
+	"vault-enabled": "Secrets stored in OS keychain",
+	"vault-disabled": "OS keychain unavailable — secrets stored in plaintext",
+	"credential-encrypted-badge": "Stored in OS keychain",
+	"credential-vault-unavailable":
+		"OS keychain not reachable; new credentials will be saved in plaintext",
 };

--- a/src/shared/locales/en-US/task.ts
+++ b/src/shared/locales/en-US/task.ts
@@ -203,6 +203,7 @@ export default {
 	"dont-save-credential": "Don't Save",
 	"credential-saved": "Credentials saved",
 	"credential-applied": "Credentials applied",
+	"credential-apply-failed": "Failed to apply credentials",
 	"credential-profile-name": "Profile Name",
 	"credential-profile-name-placeholder": "e.g. Work FTP, CDN Token",
 	"no-saved-credentials": "No saved credentials",

--- a/src/shared/locales/zh-CN/cloudSinks.ts
+++ b/src/shared/locales/zh-CN/cloudSinks.ts
@@ -134,6 +134,7 @@ export default {
 	confirmRemoveRule: "该规则将被删除，存储不受影响。",
 	errRuleSinkRequired: "请选择目标存储。",
 	errRuleSizeRange: "最小大小不能超过最大大小。",
+	credentialSyncFailed: "凭据同步失败",
 	cat_music: "音乐",
 	cat_video: "视频",
 	cat_image: "图片",

--- a/src/shared/locales/zh-CN/preferences.ts
+++ b/src/shared/locales/zh-CN/preferences.ts
@@ -187,7 +187,6 @@ export default {
 	"auto-update": "自动更新",
 	"auto-check-update": "自动检查更新",
 	"last-check-update-time": "上次检查更新时间",
-	"follow-torrent": "种子下载完后自动下载种子内容",
 	"not-saved": "设置未保存",
 	"not-saved-confirm": "已修改的设置将会丢失，确定要离开吗?",
 	"saved-credentials": "已保存的凭据",
@@ -199,4 +198,8 @@ export default {
 	"credential-last-used": "上次使用",
 	"credential-delete": "删除凭据",
 	"credential-delete-confirm": "确定要删除此保存的凭据吗？",
+	"vault-enabled": "凭据已加密存储在系统钥匙串中",
+	"vault-disabled": "系统钥匙串不可用，凭据将以明文存储",
+	"credential-encrypted-badge": "已存储在系统钥匙串中",
+	"credential-vault-unavailable": "系统钥匙串不可用；新凭据将以明文保存",
 };

--- a/src/shared/locales/zh-CN/task.ts
+++ b/src/shared/locales/zh-CN/task.ts
@@ -191,6 +191,7 @@ export default {
 	"dont-save-credential": "不保存",
 	"credential-saved": "凭据已保存",
 	"credential-applied": "凭据已应用",
+	"credential-apply-failed": "应用凭据失败",
 	"credential-profile-name": "配置名称",
 	"credential-profile-name-placeholder": "例如：工作 FTP、CDN 令牌",
 	"no-saved-credentials": "暂无保存的凭据",

--- a/src/shared/locales/zh-TW/cloudSinks.ts
+++ b/src/shared/locales/zh-TW/cloudSinks.ts
@@ -133,6 +133,7 @@ export default {
 	confirmRemoveRule: "該規則將被刪除，儲存不受影響。",
 	errRuleSinkRequired: "請選擇目標儲存。",
 	errRuleSizeRange: "最小大小不能超過最大大小。",
+	credentialSyncFailed: "憑據同步失敗",
 	cat_music: "音樂",
 	cat_video: "影片",
 	cat_image: "圖片",

--- a/src/shared/locales/zh-TW/preferences.ts
+++ b/src/shared/locales/zh-TW/preferences.ts
@@ -198,4 +198,8 @@ export default {
 	"credential-last-used": "上次使用",
 	"credential-delete": "刪除憑證",
 	"credential-delete-confirm": "確定要刪除此儲存的憑證嗎？",
+	"vault-enabled": "憑證已加密儲存在系統鑰匙圈中",
+	"vault-disabled": "系統鑰匙圈不可用，憑證將以明文儲存",
+	"credential-encrypted-badge": "已儲存在系統鑰匙圈中",
+	"credential-vault-unavailable": "系統鑰匙圈不可用；新憑證將以明文儲存",
 };

--- a/src/shared/locales/zh-TW/task.ts
+++ b/src/shared/locales/zh-TW/task.ts
@@ -191,6 +191,7 @@ export default {
 	"dont-save-credential": "不儲存",
 	"credential-saved": "憑據已儲存",
 	"credential-applied": "憑據已套用",
+	"credential-apply-failed": "套用憑據失敗",
 	"credential-profile-name": "設定檔名稱",
 	"credential-profile-name-placeholder": "例如：工作 FTP、CDN 權杖",
 	"no-saved-credentials": "尚無儲存的憑據",

--- a/src/shared/types/credential.ts
+++ b/src/shared/types/credential.ts
@@ -1,3 +1,12 @@
+/**
+ * A user-managed authentication profile applied when adding a download.
+ *
+ * Secret fields (the `CREDENTIAL_SECRET_FIELDS` set below) may be persisted
+ * either inline in `user.json` (legacy, when `vaulted` is falsy) or in the
+ * OS keychain via the Tauri `vault_*` commands (when `vaulted === true`).
+ * The non-secret metadata always stays inline so the renderer can list and
+ * match credentials without unlocking the keychain.
+ */
 export interface SavedCredential {
 	id: string;
 	label?: string;
@@ -13,4 +22,18 @@ export interface SavedCredential {
 	allProxy?: string;
 	createdAt: number;
 	lastUsedAt: number;
+	/** True when the secret fields live in the OS keychain instead of inline. */
+	vaulted?: boolean;
 }
+
+/** Sensitive fields that may be moved to the OS keychain. */
+export const CREDENTIAL_SECRET_FIELDS = [
+	"authorization",
+	"cookie",
+	"ftpUser",
+	"ftpPasswd",
+	"sftpPrivateKey",
+	"sftpPrivateKeyContent",
+	"sftpKeyPassphrase",
+	"allProxy",
+] as const satisfies ReadonlyArray<keyof SavedCredential>;

--- a/src/shared/types/credential.ts
+++ b/src/shared/types/credential.ts
@@ -24,6 +24,14 @@ export interface SavedCredential {
 	lastUsedAt: number;
 	/** True when the secret fields live in the OS keychain instead of inline. */
 	vaulted?: boolean;
+	/**
+	 * Transient flag set by callers that want `saveCredential` to drop any
+	 * existing OS-keychain entry for this credential (e.g. the user pressed
+	 * "Clear stored secret"). Not persisted — the store strips this before
+	 * writing to `user.json`. Without it, an empty secrets payload is
+	 * treated as "metadata-only edit" and the prior vault entry is kept
+	 */
+	clearVault?: boolean;
 }
 
 /** Sensitive fields that may be moved to the OS keychain. */

--- a/src/shared/types/task.ts
+++ b/src/shared/types/task.ts
@@ -1,4 +1,4 @@
-export interface FileUri {
+interface FileUri {
 	uri: string;
 	status: string;
 }
@@ -12,7 +12,7 @@ export interface DownloadFile {
 	uris: FileUri[];
 }
 
-export interface BitTorrentInfo {
+interface BitTorrentInfo {
 	info?: {
 		name?: string;
 	};

--- a/src/shared/types/upload.ts
+++ b/src/shared/types/upload.ts
@@ -3,7 +3,7 @@
 
 export type UploadProtocol = "webdav" | "s3" | "sftp" | "ftp";
 
-export interface WebdavConfig {
+interface WebdavConfig {
 	endpoint: string;
 	basePath: string;
 	username?: string;
@@ -11,7 +11,7 @@ export interface WebdavConfig {
 	insecure?: boolean;
 }
 
-export interface S3Config {
+interface S3Config {
 	endpoint: string;
 	region: string;
 	bucket: string;
@@ -23,7 +23,7 @@ export interface S3Config {
 	forcePathStyle?: boolean;
 }
 
-export interface SftpConfig {
+interface SftpConfig {
 	host: string;
 	port: number;
 	username: string;
@@ -32,7 +32,7 @@ export interface SftpConfig {
 	basePath?: string;
 }
 
-export interface FtpConfig {
+interface FtpConfig {
 	host: string;
 	port: number;
 	username?: string;
@@ -48,7 +48,7 @@ export type SinkConfig =
 	| ({ kind: "sftp" } & SftpConfig)
 	| ({ kind: "ftp" } & FtpConfig);
 
-export type PostUploadAction = "keep" | "trash" | "move";
+type PostUploadAction = "keep" | "trash" | "move";
 
 export interface UploadSinkRecord {
 	id: string;
@@ -60,7 +60,7 @@ export interface UploadSinkRecord {
 	lastUsedAt?: number | null;
 }
 
-export interface RuleMatch {
+interface RuleMatch {
 	categories: string[];
 	extensions: string[];
 	minSize?: number | null;


### PR DESCRIPTION
- Add VaultManager to store/retrieve credentials in the OS keychain.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an OS-keychain-backed credential vault so saved credentials and upload sink secrets are stored securely in the system keychain, with automatic fallback to plaintext when unavailable. Upload sinks and task credentials now rehydrate secrets on startup/use, removing the need to re-enter passwords.

- **New Features**
  - Added Rust `VaultManager` using `keyring`, plus Tauri commands: `vault_status`, `vault_put_credential`, `vault_get_credential`, `vault_remove_credential`.
  - Upload sinks: extract passwords/keys to the vault on add/update; rehydrate on app start; clear vault entries on removal; never block on vault failures.
  - Preferences: probe vault on load; split saved credentials into metadata (stored) and secrets (vault); mark items as `vaulted`; lazy fetch secrets when applying to tasks.
  - UI: Credential Manager shows vault status and a “vaulted” badge; Cloud Sinks syncs sink records into saved credentials without duplicating secrets in `user.json`.

- **Dependencies**
  - Added `keyring` (features: `apple-native`, `windows-native`, `sync-secret-service`).

<sup>Written for commit df9c244b9b4fafcedab6ee6058229c2a6411bd71. Summary will update on new commits. <a href="https://cubic.dev/pr/YueMiyuki/Risuko/pull/54?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OS credential vault (system keychain) with new commands and renderer API to put/get/remove credentials; vault rehydrates upload sink secrets on startup.
  * Upload sinks auto-sync credentials with the vault; sink create/update/delete preserve or clear secrets appropriately.
  * Preferences/UI updates: vault status, vaulted badges, credential sync/error messages, async credential apply/load flows.

* **Tests**
  * Extensive new unit/integration tests across config, RSS, upload, vault, and command surfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->