### PR TITLE
Use lower version of ubuntu for building

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -35,11 +35,11 @@ jobs:
             binary: risuko
             npm_dir: darwin-x64
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-22.04
             binary: risuko
             npm_dir: linux-x64-gnu
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-24.04-arm
+            os: ubuntu-22.04-arm
             binary: risuko
             npm_dir: linux-arm64-gnu
           - target: x86_64-pc-windows-msvc
@@ -69,9 +69,18 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libssl-dev pkg-config
 
+      - name: Install cross for Linux baseline builds
+        if: startsWith(matrix.os, 'ubuntu')
+        run: cargo install cross --locked
+
       - name: Build risuko-cli
         working-directory: src-tauri
-        run: cargo build --release --target ${{ matrix.target }} -p risuko-cli
+        run: |
+          if [[ "${{ runner.os }}" == "Linux" ]]; then
+            cross build --release --target ${{ matrix.target }} -p risuko-cli
+          else
+            cargo build --release --target ${{ matrix.target }} -p risuko-cli
+          fi
 
       - name: Upload binary artifact
         uses: actions/upload-artifact@v4
@@ -118,11 +127,11 @@ jobs:
             node_file: risuko.darwin-x64.node
             npm_dir: darwin-x64
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-22.04
             node_file: risuko.linux-x64-gnu.node
             npm_dir: linux-x64-gnu
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-24.04-arm
+            os: ubuntu-22.04-arm
             node_file: risuko.linux-arm64-gnu.node
             npm_dir: linux-arm64-gnu
           - target: x86_64-pc-windows-msvc
@@ -152,9 +161,18 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libssl-dev pkg-config
 
+      - name: Install cross for Linux baseline builds
+        if: startsWith(matrix.os, 'ubuntu')
+        run: cargo install cross --locked
+
       - name: Build risuko-napi
         working-directory: src-tauri
-        run: cargo build --release --target ${{ matrix.target }} -p risuko-napi
+        run: |
+          if [[ "${{ runner.os }}" == "Linux" ]]; then
+            cross build --release --target ${{ matrix.target }} -p risuko-napi
+          else
+            cargo build --release --target ${{ matrix.target }} -p risuko-napi
+          fi
 
       - name: Rename .node artifact
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,11 +26,11 @@ jobs:
             target: aarch64-apple-darwin
             tauri_args: --config src-tauri/tauri.darwin.arm64.conf.json
           - platform: linux/x64
-            os: ubuntu-latest
+            os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             tauri_args: --config src-tauri/tauri.linux.x64.conf.json
           - platform: linux/arm64
-            os: ubuntu-24.04-arm
+            os: ubuntu-22.04-arm
             target: aarch64-unknown-linux-gnu
             tauri_args: --config src-tauri/tauri.linux.arm64.conf.json
           - platform: win32/x64
@@ -61,6 +61,11 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
+
+      - name: Install cross for Linux baseline CLI builds
+        if: startsWith(matrix.os, 'ubuntu')
+        shell: bash
+        run: cargo install cross --locked
 
       - name: Install Linux build dependencies
         if: startsWith(matrix.os, 'ubuntu')
@@ -227,7 +232,12 @@ jobs:
       - name: Build risuko-cli binary
         if: matrix.target != 'i686-pc-windows-msvc'
         working-directory: src-tauri
-        run: cargo build --release --target ${{ matrix.target }} -p risuko-cli
+        run: |
+          if [[ "${{ runner.os }}" == "Linux" ]]; then
+            cross build --release --target ${{ matrix.target }} -p risuko-cli
+          else
+            cargo build --release --target ${{ matrix.target }} -p risuko-cli
+          fi
 
       - name: Package risuko-cli binary (unix)
         if: matrix.target != 'i686-pc-windows-msvc' && runner.os != 'Windows'


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Pin Linux builds to Ubuntu 22.04 and use `cross` for Linux compilation to stabilize CI and produce more compatible binaries. This reduces Linux build failures and avoids `ubuntu-latest` drift.

- **Refactors**
  - Replace `ubuntu-latest` and `ubuntu-24.04-arm` with `ubuntu-22.04` and `ubuntu-22.04-arm` in `publish-npm.yml` and `release.yml`.
  - Install `cross` on Linux runners; use it to build `risuko-cli` and `risuko-napi`. Keep `cargo build` on macOS and Windows.
  - Keep Linux deps install (`libssl-dev`, `pkg-config`).

<sup>Written for commit 9d35d095db23a45488bb45e78c0e1b6cd22deb15. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

