### PR TITLE
fix(rpc): enforce per-call auth in system.multicall

### DIFF
--- a/src-tauri/risuko-engine/src/engine/rpc.rs
+++ b/src-tauri/risuko-engine/src/engine/rpc.rs
@@ -471,6 +471,14 @@ fn should_skip_outer_auth(method: &str) -> bool {
     method == "system.multicall"
 }
 
+/// Extract the nested multicall list from either the standard `[[calls]]`
+/// shape or the legacy `["token:...", [calls]]` shape
+///
+/// This helper only returns the inner call array. It does not validate or use
+/// the outer `"token:..."` value for authentication; outer auth is
+/// intentionally ignored for `system.multicall`, and each nested call is
+/// authenticated independently. Malformed shapes return an empty `Vec`, so the
+/// `starts_with("token:")` check here is shape detection, not auth logic
 fn extract_multicall_methods(params: &[Value]) -> Vec<Value> {
     // Accept both formats:
     // 1) standard aria2: [ [ { methodName, params } ] ]

--- a/src-tauri/risuko-engine/src/engine/rpc.rs
+++ b/src-tauri/risuko-engine/src/engine/rpc.rs
@@ -945,6 +945,33 @@ fn get_keys(params: &[Value], index: usize) -> Vec<String> {
 mod tests {
     use super::*;
     use serde_json::json;
+    use tempfile::TempDir;
+
+    async fn make_rpc_state(secret: &str) -> (RpcState, TempDir) {
+        let events = EventBroadcaster::default();
+        let config_dir = TempDir::new().unwrap();
+        let options = super::super::options::EngineOptions::from_config(
+            &serde_json::Map::new(),
+            &serde_json::Map::new(),
+        );
+        let manager = Arc::new(
+            TaskManager::new(config_dir.path(), options, events.clone())
+                .await
+                .unwrap(),
+        );
+        let (rpc_shutdown_tx, _rpc_shutdown_rx) = tokio::sync::mpsc::channel(1);
+
+        (
+            RpcState {
+                manager,
+                events,
+                secret: secret.to_string(),
+                session_id: "test-session".to_string(),
+                rpc_shutdown_tx,
+            },
+            config_dir,
+        )
+    }
 
     // -- check_auth --
 
@@ -1057,6 +1084,89 @@ mod tests {
         let params = vec![json!("secret"), json!([call])];
         let methods = extract_multicall_methods(&params);
         assert!(methods.is_empty());
+    }
+
+    #[tokio::test]
+    async fn multicall_mixed_nested_auth_standard_shape_keeps_processing() {
+        let (state, _config_dir) = make_rpc_state("secret").await;
+        let request = json!({
+            "jsonrpc": "2.0",
+            "id": "1",
+            "method": "system.multicall",
+            "params": [[
+                {
+                    "methodName": "aria2.getVersion",
+                    "params": []
+                },
+                {
+                    "methodName": "aria2.getVersion",
+                    "params": ["token:secret"]
+                }
+            ]]
+        });
+
+        let response = process_single_request(&state, request).await.unwrap();
+        let results = response
+            .get("result")
+            .and_then(|v| v.as_array())
+            .unwrap();
+
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].get("code").and_then(|v| v.as_i64()), Some(1));
+        assert_eq!(
+            results[0].get("message").and_then(|v| v.as_str()),
+            Some("Unauthorized")
+        );
+
+        let success = results[1].as_array().unwrap();
+        let version_obj = success.first().and_then(|v| v.as_object()).unwrap();
+        assert_eq!(
+            version_obj.get("version").and_then(|v| v.as_str()),
+            Some(ENGINE_VERSION)
+        );
+    }
+
+    #[tokio::test]
+    async fn multicall_mixed_nested_auth_legacy_shape_keeps_processing() {
+        let (state, _config_dir) = make_rpc_state("secret").await;
+        let request = json!({
+            "jsonrpc": "2.0",
+            "id": "1",
+            "method": "system.multicall",
+            "params": [
+                "token:secret",
+                [
+                    {
+                        "methodName": "aria2.getVersion",
+                        "params": ["token:wrong"]
+                    },
+                    {
+                        "methodName": "aria2.getVersion",
+                        "params": ["token:secret"]
+                    }
+                ]
+            ]
+        });
+
+        let response = process_single_request(&state, request).await.unwrap();
+        let results = response
+            .get("result")
+            .and_then(|v| v.as_array())
+            .unwrap();
+
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].get("code").and_then(|v| v.as_i64()), Some(1));
+        assert_eq!(
+            results[0].get("message").and_then(|v| v.as_str()),
+            Some("Unauthorized")
+        );
+
+        let success = results[1].as_array().unwrap();
+        let version_obj = success.first().and_then(|v| v.as_object()).unwrap();
+        assert_eq!(
+            version_obj.get("version").and_then(|v| v.as_str()),
+            Some(ENGINE_VERSION)
+        );
     }
 
     // -- get_gid --

--- a/src-tauri/risuko-engine/src/engine/rpc.rs
+++ b/src-tauri/risuko-engine/src/engine/rpc.rs
@@ -400,8 +400,13 @@ async fn process_single_request(state: &RpcState, request: Value) -> Option<Valu
         _ => vec![params],
     };
 
-    // Auth check
-    let (authed_params, auth_ok) = check_auth(&state.secret, params_vec);
+    // aria2 special-case: system.multicall does not require outer auth
+    // Each nested call is authenticated independently
+    let (authed_params, auth_ok) = if should_skip_outer_auth(method) {
+        (params_vec, true)
+    } else {
+        check_auth(&state.secret, params_vec)
+    };
     if !auth_ok {
         return Some(rpc_error(id.unwrap_or(Value::Null), 1, "Unauthorized"));
     }
@@ -460,6 +465,29 @@ fn normalize_method(method: &str) -> String {
     } else {
         method.to_string()
     }
+}
+
+fn should_skip_outer_auth(method: &str) -> bool {
+    method == "system.multicall"
+}
+
+fn extract_multicall_methods(params: &[Value]) -> Vec<Value> {
+    // Accept both formats:
+    // 1) standard aria2: [ [ { methodName, params } ] ]
+    // 2) backward-compatible legacy: [ "token:...", [ { methodName, params } ] ]
+    params
+        .first()
+        .and_then(|v| v.as_array())
+        .or_else(|| {
+            params.get(1).and_then(|v| v.as_array()).filter(|_| {
+                params
+                    .first()
+                    .and_then(|v| v.as_str())
+                    .is_some_and(|s| s.starts_with("token:"))
+            })
+        })
+        .cloned()
+        .unwrap_or_default()
 }
 
 struct RpcError {
@@ -770,11 +798,7 @@ fn dispatch_method<'a>(
             })),
 
             "system.multicall" => {
-                let methods = params
-                    .first()
-                    .and_then(|v| v.as_array())
-                    .cloned()
-                    .unwrap_or_default();
+                let methods = extract_multicall_methods(&params);
 
                 let mut results = Vec::with_capacity(methods.len());
                 for call in methods {
@@ -788,7 +812,15 @@ fn dispatch_method<'a>(
                         .cloned()
                         .unwrap_or_default();
 
-                    let (clean_params, _) = check_auth(&state.secret, call_params);
+                    let (clean_params, auth_ok) = check_auth(&state.secret, call_params);
+                    if !auth_ok {
+                        results.push(json!({
+                            "code": 1,
+                            "message": "Unauthorized",
+                        }));
+                        continue;
+                    }
+
                     let normalized = normalize_method(method_name);
 
                     match dispatch_method(state, &normalized, clean_params).await {
@@ -983,6 +1015,48 @@ mod tests {
     fn normalize_passthrough() {
         assert_eq!(normalize_method("risuko.addUri"), "risuko.addUri");
         assert_eq!(normalize_method("system.listMethods"), "system.listMethods");
+    }
+
+    // -- multicall helpers --
+
+    #[test]
+    fn skip_outer_auth_only_for_system_multicall() {
+        assert!(should_skip_outer_auth("system.multicall"));
+        assert!(!should_skip_outer_auth("aria2.tellActive"));
+        assert!(!should_skip_outer_auth("risuko.tellActive"));
+    }
+
+    #[test]
+    fn extract_multicall_methods_standard_shape() {
+        let call = json!({
+            "methodName": "aria2.tellActive",
+            "params": ["token:secret", ["gid"]]
+        });
+        let params = vec![json!([call.clone()])];
+        let methods = extract_multicall_methods(&params);
+        assert_eq!(methods, vec![call]);
+    }
+
+    #[test]
+    fn extract_multicall_methods_legacy_shape() {
+        let call = json!({
+            "methodName": "aria2.tellActive",
+            "params": ["token:secret", ["gid"]]
+        });
+        let params = vec![json!("token:secret"), json!([call.clone()])];
+        let methods = extract_multicall_methods(&params);
+        assert_eq!(methods, vec![call]);
+    }
+
+    #[test]
+    fn extract_multicall_methods_rejects_second_arg_without_token_prefix() {
+        let call = json!({
+            "methodName": "aria2.tellActive",
+            "params": ["token:secret", ["gid"]]
+        });
+        let params = vec![json!("secret"), json!([call])];
+        let methods = extract_multicall_methods(&params);
+        assert!(methods.is_empty());
     }
 
     // -- get_gid --


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforce per-call authentication for `system.multicall` to match `aria2`. The outer call no longer needs a token; each sub-call is checked, unauthorized ones return an error while others continue.

- **Bug Fixes**
  - Skip outer auth only for `system.multicall` via `should_skip_outer_auth`; sub-calls use `check_auth`.
  - Support both standard `[[calls]]` and legacy `["token:...", [calls]]` shapes with `extract_multicall_methods`; reject legacy calls without the `token:` prefix.
  - Added tests for shape handling and mixed authorized/unauthorized sub-calls to ensure continued processing.

<sup>Written for commit 8033ab6cb4136698b610bcce2f92b740b7c86ffe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * system.multicall now skips outer authentication when appropriate, authenticates each nested call independently, and returns per-call Unauthorized results without failing the whole batch. Supports both standard and legacy multicall parameter formats and rejects invalid legacy token placement.

* **Tests**
  * Added unit tests and test scaffolding covering multicall auth behavior and supported parameter shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->