### PR TITLE
Fix WebKitGTK EGL Issue

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -47,7 +47,32 @@ fn init_logging(
     guard
 }
 
+/// Apply environment workarounds for known WebKitGTK/Linux rendering issues
+/// before any GTK/WebKit code initializes. Only sets variables that are not
+/// already defined, so users can override.
+#[cfg(target_os = "linux")]
+fn apply_linux_webkit_workarounds() {
+    // WebKitGTK's DMA-BUF renderer (default since 2.42) frequently fails to
+    // initialize EGL/GBM on NVIDIA, virtualized GPUs, Wayland sessions without
+    // a working GBM backend, or older Mesa stacks. The failure manifests as:
+    //   "Could not create GBM EGL display: EGL_NOT_INITIALIZED. Aborting..."
+    // followed by SIGABRT before the window is shown.
+    // Disabling DMA-BUF forces the legacy GLES path which is far more
+    // compatible. See: https://github.com/tauri-apps/tauri/issues/9304
+    for (key, value) in [
+        ("WEBKIT_DISABLE_DMABUF_RENDERER", "1"),
+        ("WEBKIT_DISABLE_COMPOSITING_MODE", "1"),
+    ] {
+        if std::env::var_os(key).is_none() {
+            std::env::set_var(key, value);
+        }
+    }
+}
+
 pub fn run() {
+    #[cfg(target_os = "linux")]
+    apply_linux_webkit_workarounds();
+
     let app = tauri::Builder::default()
         .plugin(tauri_plugin_store::Builder::default().build())
         .plugin(tauri_plugin_dialog::init())


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a Linux startup crash where WebKitGTK aborts with “EGL_NOT_INITIALIZED” by applying safe renderer defaults before initialization. Improves stability on NVIDIA GPUs, VMs, and older Mesa/Wayland setups.

- **Bug Fixes**
  - On Linux, set `WEBKIT_DISABLE_DMABUF_RENDERER=1` and `WEBKIT_DISABLE_COMPOSITING_MODE=1` if unset, before any GTK/WebKit code runs.
  - Respects user overrides by not changing variables that are already set.

<sup>Written for commit 4c5ed509df8385d4c42a8dfac820ed2e9f3f9e8e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved rendering and initialization issues on Linux systems. The application now applies targeted configuration adjustments during startup to improve overall stability and prevent graphics-related display failures that previously affected Linux users.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/YueMiyuki/Risuko/pull/70)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->