### PR TITLE
Add flush tasks on restart and fix BT performance

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1_bug_report.yml
@@ -77,5 +77,5 @@ body:
           required: true
         - label: You have tried with test URL https://cdn.hotelnearmedanta.com/testfile.org/testfile.org-5GB.dat and the bug still occurs.
           required: true
-        - label: You have provided logs (In Preference - Advanced - Log level set to Debug, Reproduce the erorr and find log file by clicking "Open log file" in the same page)
+        - label: You have provided logs (In Preference - Advanced - Log level set to Debug, Reproduce the error and find log file by clicking "Open log file" in the same page)
           required: true

--- a/.github/ISSUE_TEMPLATE/1_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1_bug_report.yml
@@ -77,3 +77,5 @@ body:
           required: true
         - label: You have tried with test URL https://cdn.hotelnearmedanta.com/testfile.org/testfile.org-5GB.dat and the bug still occurs.
           required: true
+        - label: You have provided logs (In Preference - Advanced - Log level set to Debug, Reproduce the erorr and find log file by clicking "Open log file" in the same page)
+          required: true

--- a/.github/ISSUE_TEMPLATE/2_bug_report_cn.yml
+++ b/.github/ISSUE_TEMPLATE/2_bug_report_cn.yml
@@ -77,3 +77,5 @@ body:
           required: true
         - label: 您已经尝试使用测试 URL https://cdn.hotelnearmedanta.com/testfile.org/testfile.org-5GB.dat，并且该 Bug 仍然存在。
           required: true
+        - label: 您已经提供了日志（在首选项 - 高级 - 日志级别设置为调试，重现错误并通过点击同一页面的“打开日志文件”找到日志文件）
+          required: true

--- a/.github/ISSUE_TEMPLATE/2_bug_report_cn.yml
+++ b/.github/ISSUE_TEMPLATE/2_bug_report_cn.yml
@@ -77,5 +77,5 @@ body:
           required: true
         - label: 您已经尝试使用测试 URL https://cdn.hotelnearmedanta.com/testfile.org/testfile.org-5GB.dat，并且该 Bug 仍然存在。
           required: true
-        - label: 您已经提供了日志（在首选项 - 高级 - 日志级别设置为调试，重现错误并通过点击同一页面的“打开日志文件”找到日志文件）
+        - label: 您已经提供了日志（在首选项 → 进阶设置 → 应用日志路径，或在健康检查 → 工具 → 打开日志目录）
           required: true

--- a/src-tauri/risuko-bt/src/torrent.rs
+++ b/src-tauri/risuko-bt/src/torrent.rs
@@ -62,6 +62,29 @@ const MAX_PENDING_DIALS: usize = 256;
 /// keeps pipeline utilisation high all the way through the last 1 %
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(8);
 
+/// Disconnect peers that have not sent us any wire message for this long.
+/// The reader task has no per-read timeout post-handshake (a deliberate
+/// choice to keep the hot-path zero-cost), so without an idle eviction in
+/// the torrent loop a peer killed by a NAT idle expiry, an ISP-throttled
+/// black-holed TCP session, or a peer that crashed without sending RST
+/// will sit in `peers` forever, occupying one of the `max_peers` slots
+/// and excluding fresh tracker / DHT addresses from being dialled. Once
+/// enough peers reach this state — typical on long-running downloads
+/// against swarms with many flaky NAT-ed leechers — `peers.len() ==
+/// max_peers` and the global download rate collapses even while the UI
+/// still reports a healthy peer count. 180 s is 2× our 90 s KeepAlive
+/// cadence so a healthy peer that only ever sends KeepAlive (e.g. two
+/// idle seeders sharing nothing) is never evicted in error
+const PEER_IDLE_TIMEOUT: Duration = Duration::from_secs(180);
+
+/// A peer marked `snubbing` (one of its chunk requests timed out) is
+/// excluded from new request allocation until it delivers any Piece. If
+/// it never delivers, the soft back-off becomes a permanent slot leak —
+/// see `PEER_IDLE_TIMEOUT` for the same effect via a different path. We
+/// hard-disconnect peers that stay snubbed for this long so the slot is
+/// recycled to a peer that can actually serve us bytes
+const SNUB_EVICTION_TIMEOUT: Duration = Duration::from_secs(60);
+
 /// Per-peer message id we advertise for the BEP-9 `ut_metadata` extension.
 /// Peers send `Extended { ext_id: OUR_UT_METADATA_ID, .. }` to request a
 /// 16 KiB chunk of our raw `info` dict
@@ -213,6 +236,18 @@ struct Peer {
     /// peers — the slow-decay cause of the
     /// "speed great at first, then degrades over minutes" pattern
     snubbing: bool,
+    /// Instant we last received any wire message from this peer. Updated
+    /// on every `PeerEvent::Message` arrival; consulted by the tick to
+    /// evict peers idle past [`PEER_IDLE_TIMEOUT`]. Initialised on
+    /// adoption / handshake so a peer is never evicted before it has had
+    /// a chance to send anything
+    last_recv: Instant,
+    /// Instant the `snubbing` flag was last set, or `None` if not
+    /// snubbing. Consulted by the tick to evict peers that stay snubbed
+    /// past [`SNUB_EVICTION_TIMEOUT`] (otherwise a peer whose requests
+    /// keep timing out occupies a slot indefinitely without serving any
+    /// bytes)
+    snub_since: Option<Instant>,
     /// Per-peer message id the remote advertised for `ut_metadata` in its
     /// BEP-10 extended handshake. `None` until that handshake is received.
     /// We never *initiate* a `ut_metadata` request from the torrent loop
@@ -523,7 +558,10 @@ async fn torrent_loop(
                     // the actually-stuck peers, transiently
                     for r in &reclaimed {
                         if let Some(p) = peers.get_mut(&r.peer) {
-                            p.snubbing = true;
+                            if !p.snubbing {
+                                p.snubbing = true;
+                                p.snub_since = Some(Instant::now());
+                            }
                         }
                         unblocked_pieces.insert(r.piece);
                         // Free the peer's outstanding slot so drive_peer
@@ -552,6 +590,53 @@ async fn torrent_loop(
                     for pi in unblocked_pieces {
                         if let Ok(vpi) = lengths.validate_piece(pi) {
                             piece_tracker.clear_in_flight(vpi);
+                        }
+                    }
+                }
+                // Evict peers that have gone silent or stayed snubbed for
+                // too long. Without this sweep their slot is held until
+                // the (currently absent) reader-side timeout fires — i.e.
+                // never — so peers leak permanently and `peers.len()`
+                // saturates at `max_peers`, blocking fresh tracker / DHT
+                // addresses. This is the dominant cause of "download speed
+                // is great at first then collapses to 0 after a while":
+                // each silent / snubbed peer parks a slot, and the
+                // reclaim/snub mechanism alone can't free it because the
+                // peer never delivers anything to clear `snubbing`.
+                {
+                    let mut to_evict: Vec<u32> = Vec::new();
+                    for (&pid, p) in peers.iter() {
+                        if now.duration_since(p.last_recv) > PEER_IDLE_TIMEOUT {
+                            to_evict.push(pid);
+                            continue;
+                        }
+                        if let Some(snub_at) = p.snub_since {
+                            if now.duration_since(snub_at) > SNUB_EVICTION_TIMEOUT {
+                                to_evict.push(pid);
+                            }
+                        }
+                    }
+                    for pid in to_evict {
+                        if let Some(p) = peers.remove(&pid) {
+                            // Free the peer's address so the tracker /
+                            // DHT can re-dial it later. Drop bitfield
+                            // contributions and chunk reservations the
+                            // same way a Disconnected event would
+                            known_addrs.remove(&p.addr);
+                            let _ = p.cmd_tx.try_send(PeerCommand::Disconnect);
+                            piece_tracker.remove_peer_bitfield(&p.bitfield);
+                            let freed = chunk_tracker.release_peer(pid);
+                            for piece_idx in freed {
+                                if let Ok(vpi) = lengths.validate_piece(piece_idx) {
+                                    piece_tracker.clear_in_flight(vpi);
+                                }
+                                let should_drop = piece_assemblies
+                                    .get(&piece_idx)
+                                    .is_none_or(|a| a.received_chunks.is_empty());
+                                if should_drop {
+                                    piece_assemblies.remove(&piece_idx);
+                                }
+                            }
                         }
                     }
                 }
@@ -676,6 +761,8 @@ async fn adopt_inbound_peer(
             max_outstanding: pipeline_floor,
             received_since_grow: 0,
             snubbing: false,
+            last_recv: Instant::now(),
+            snub_since: None,
             their_ut_metadata_id: None,
             sent_ext_handshake: false,
         },
@@ -764,6 +851,8 @@ async fn process_peer_event(
                             max_outstanding: pipeline_floor,
                             received_since_grow: 0,
                             snubbing: false,
+                            last_recv: Instant::now(),
+                            snub_since: None,
                             their_ut_metadata_id: None,
                             sent_ext_handshake: false,
                         },
@@ -808,6 +897,12 @@ async fn process_peer_event(
             let Some(peer) = peers.get_mut(&pid) else {
                 return false;
             };
+            // Refresh per-peer liveness on every wire message (including
+            // KeepAlive / Choke / Have, not just Piece). The torrent loop's
+            // tick uses this to evict peers idle past PEER_IDLE_TIMEOUT
+            // and recycle their slot to a fresh dial \u2014 see the eviction
+            // sweep in the `tick.tick()` arm
+            peer.last_recv = Instant::now();
             match msg {
                 Message::Choke => peer.peer_choking = true,
                 Message::Unchoke => {
@@ -913,6 +1008,7 @@ async fn process_peer_event(
                     // session is allowed back into the request rotation
                     // as soon as it proves it can still deliver bytes
                     peer.snubbing = false;
+                    peer.snub_since = None;
                     // Adaptive pipeline grow: count successful
                     // deliveries in the current window, double the per-peer
                     // cap when 25 % of the cap has landed (cap at

--- a/src-tauri/risuko-engine/src/config/defaults.rs
+++ b/src-tauri/risuko-engine/src/config/defaults.rs
@@ -91,6 +91,7 @@ pub fn user_defaults() -> Map<String, Value> {
         }),
     );
     m.insert("rpc-host".into(), json!("127.0.0.1"));
+    m.insert("purge-record-on-start".into(), json!(false));
     m.insert("resume-all-when-app-launched".into(), json!(false));
     m.insert("run-mode".into(), json!(1));
     m.insert("show-progress-bar".into(), json!(true));

--- a/src-tauri/risuko-engine/src/config/defaults.rs
+++ b/src-tauri/risuko-engine/src/config/defaults.rs
@@ -191,6 +191,8 @@ mod tests {
         assert_eq!(user.get("keep-seeding").unwrap(), false);
         assert_eq!(user.get("rpc-host").unwrap(), "127.0.0.1");
         assert_eq!(user.get("m3u8-output-format").unwrap(), "ts");
+        // Regression: purge-record-on-start defaults to false
+        assert_eq!(user.get("purge-record-on-start").unwrap(), false);
     }
 
     #[cfg(target_os = "macos")]

--- a/src-tauri/risuko-engine/src/engine/manager.rs
+++ b/src-tauri/risuko-engine/src/engine/manager.rs
@@ -86,7 +86,11 @@ impl TaskManager {
         events: EventBroadcaster,
     ) -> Result<Self, String> {
         let session = SessionManager::new(config_dir);
-        let saved_tasks = session.load();
+        let mut saved_tasks = session.load();
+
+        if options.purge_record_on_start() {
+            saved_tasks.retain(|t| !t.status.is_stopped());
+        }
 
         let output_dir = options.dir();
         let tuning = super::torrent::BtTuning {
@@ -184,7 +188,7 @@ impl TaskManager {
         // Without this, librqbit auto-resumes them on startup and writes files
         // even though the user has deleted or never had the task in Motrix.
         for (librqbit_id, info_hash) in orphans {
-            match te.remove(librqbit_id).await {
+            match te.remove(librqbit_id, true).await {
                 Ok(()) => log::info!(
                     "Purged orphan persisted torrent: librqbit_id={} ({})",
                     librqbit_id,
@@ -2057,7 +2061,7 @@ impl TaskManager {
             if let Some(&tid) = tid_guard.get(gid) {
                 let te_guard = self.torrent_engine.read().await;
                 if let Some(ref te) = *te_guard {
-                    te.remove(tid).await.ok();
+                    te.remove(tid, true).await.ok();
                 }
             }
         }
@@ -2544,11 +2548,40 @@ impl TaskManager {
     }
 
     pub async fn purge_download_result(&self) {
+        // Collect gids of stopped torrent tasks so we can drop their bt-session
+        // entries before evicting them from the task list. Without this, the
+        // bt session keeps the info-hash registered in `by_hash` and a later
+        // re-add of the same magnet short-circuits to `AlreadyManaged` with
+        // the old finished handle (UI shows "completed" with no download).
+        let stopped_torrent_gids: Vec<String> = {
+            let tasks = self.tasks.read().await;
+            tasks
+                .iter()
+                .filter(|t| t.status.is_stopped() && t.kind == TaskKind::Torrent)
+                .map(|t| t.gid.clone())
+                .collect()
+        };
+        for gid in &stopped_torrent_gids {
+            self.drop_torrent_engine_entry(gid).await;
+        }
         let mut tasks = self.tasks.write().await;
         tasks.retain(|t| !t.status.is_stopped());
     }
 
     pub async fn remove_download_result(&self, gid: &str) -> Result<(), String> {
+        // Drop the bt-session entry first (keep files on disk — this is a
+        // "remove from history" operation, not a payload deletion). Without
+        // this, the `by_hash` map retains the info-hash and re-adding the
+        // same magnet returns the stale completed torrent until restart.
+        let is_stopped_torrent = {
+            let tasks = self.tasks.read().await;
+            tasks
+                .iter()
+                .any(|t| t.gid == gid && t.status.is_stopped() && t.kind == TaskKind::Torrent)
+        };
+        if is_stopped_torrent {
+            self.drop_torrent_engine_entry(gid).await;
+        }
         let mut tasks = self.tasks.write().await;
         let len_before = tasks.len();
         tasks.retain(|t| !(t.gid == gid && t.status.is_stopped()));
@@ -2556,6 +2589,27 @@ impl TaskManager {
             Ok(())
         } else {
             Err(format!("GID {} not found or not stopped", gid))
+        }
+    }
+
+    /// Drop a torrent task's entry from the underlying bt session WITHOUT
+    /// touching on-disk files, and clear the gid->torrent-id mapping. Used
+    /// by `remove_download_result` / `purge_download_result` to prevent
+    /// stale `by_hash` entries from blocking re-adds of the same magnet.
+    async fn drop_torrent_engine_entry(&self, gid: &str) {
+        let maybe_tid = self.torrent_ids.write().await.remove(gid);
+        if let Some(tid) = maybe_tid {
+            let te_guard = self.torrent_engine.read().await;
+            if let Some(ref te) = *te_guard {
+                if let Err(e) = te.remove(tid, false).await {
+                    log::warn!(
+                        "[task:{}] failed to drop torrent engine entry (id={}): {}",
+                        gid,
+                        tid,
+                        e
+                    );
+                }
+            }
         }
     }
 

--- a/src-tauri/risuko-engine/src/engine/manager.rs
+++ b/src-tauri/risuko-engine/src/engine/manager.rs
@@ -20,6 +20,7 @@ use super::task::{
 use super::torrent::{self, TorrentEngine};
 use super::upload::UploadFileSnapshot;
 use super::youtube;
+use std::collections::HashSet;
 
 struct ActiveDownload {
     cancel: Arc<AtomicBool>,
@@ -36,6 +37,7 @@ pub struct TaskManager {
     tasks: Arc<RwLock<Vec<DownloadTask>>>,
     active_downloads: Arc<RwLock<HashMap<String, ActiveDownload>>>,
     torrent_ids: Arc<RwLock<HashMap<String, usize>>>,
+    purged_hashes: Arc<RwLock<HashSet<String>>>,
     options: Arc<RwLock<EngineOptions>>,
     events: EventBroadcaster,
     session: SessionManager,
@@ -88,7 +90,7 @@ impl TaskManager {
         let session = SessionManager::new(config_dir);
         let mut saved_tasks = session.load();
 
-        let mut purged_hashes: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let mut purged_hashes: HashSet<String> = HashSet::new();
         if options.purge_record_on_start() {
             for task in saved_tasks.iter() {
                 if task.status.is_stopped() {
@@ -125,6 +127,7 @@ impl TaskManager {
             tasks: Arc::new(RwLock::new(saved_tasks)),
             active_downloads: Arc::new(RwLock::new(HashMap::new())),
             torrent_ids: Arc::new(RwLock::new(HashMap::new())),
+            purged_hashes: Arc::new(RwLock::new(purged_hashes)),
             options: Arc::new(RwLock::new(options)),
             events,
             session,
@@ -133,7 +136,9 @@ impl TaskManager {
         };
 
         // Restore torrent_ids mapping from persisted librqbit session
-        manager.restore_torrent_mappings(purged_hashes).await;
+        if manager.restore_torrent_mappings().await {
+            manager.purged_hashes.write().await.clear();
+        }
 
         Ok(manager)
     }
@@ -141,21 +146,20 @@ impl TaskManager {
     /// restarted, match persisted librqbit torrents back to saved tasks by info_hash.
     /// Any persisted librqbit torrent with no matching live task is purged from
     /// the librqbit session so it does not silently resume downloading on startup.
-    /// purged_hashes: info_hashes of tasks removed due to purge_record_on_start;
-    /// these are preserved on disk (files kept) but records removed from librqbit.
-    async fn restore_torrent_mappings(
-        &self,
-        purged_hashes: std::collections::HashSet<String>,
-    ) {
+    /// purge provenance stays on the manager until this cleanup completes successfully.
+    async fn restore_torrent_mappings(&self) -> bool {
         let te_guard = self.torrent_engine.read().await;
-        let Some(ref te) = *te_guard else { return };
+        let Some(ref te) = *te_guard else { return false };
+
+        let purged_hashes = self.purged_hashes.read().await.clone();
 
         let managed = te.list_managed_torrents();
         if managed.is_empty() {
-            return;
+            return true;
         }
 
         let mut orphans: Vec<(usize, String)> = Vec::new();
+        let mut cleanup_failed = false;
 
         {
             let mut tasks = self.tasks.write().await;
@@ -203,7 +207,9 @@ impl TaskManager {
         // However, if the orphan came from purge_record_on_start, preserve files.
         for (librqbit_id, info_hash) in orphans {
             let delete_files = !purged_hashes.contains(&info_hash);
-            match te.remove(librqbit_id, delete_files).await {
+            let removal_result = te.remove(librqbit_id, delete_files).await;
+            let removal_failed = removal_result.is_err();
+            match removal_result {
                 Ok(()) => log::info!(
                     "Purged orphan persisted torrent: librqbit_id={} ({}) [delete_files={}]",
                     librqbit_id,
@@ -217,7 +223,12 @@ impl TaskManager {
                     e
                 ),
             }
+            if removal_failed {
+                cleanup_failed = true;
+            }
         }
+
+        !cleanup_failed
     }
 
     /// Resolve download directory and tag for a new task by evaluating routing
@@ -2613,20 +2624,26 @@ impl TaskManager {
     /// by `remove_download_result` / `purge_download_result` to prevent
     /// stale `by_hash` entries from blocking re-adds of the same magnet.
     async fn drop_torrent_engine_entry(&self, gid: &str) {
-        let maybe_tid = self.torrent_ids.write().await.remove(gid);
-        if let Some(tid) = maybe_tid {
-            let te_guard = self.torrent_engine.read().await;
-            if let Some(ref te) = *te_guard {
-                if let Err(e) = te.remove(tid, false).await {
-                    log::warn!(
-                        "[task:{}] failed to drop torrent engine entry (id={}): {}",
-                        gid,
-                        tid,
-                        e
-                    );
-                }
+        let tid = {
+            let tid_guard = self.torrent_ids.read().await;
+            tid_guard.get(gid).copied()
+        };
+        let Some(tid) = tid else { return };
+
+        let te_guard = self.torrent_engine.read().await;
+        if let Some(ref te) = *te_guard {
+            if let Err(e) = te.remove(tid, false).await {
+                log::warn!(
+                    "[task:{}] failed to drop torrent engine entry (id={}): {}",
+                    gid,
+                    tid,
+                    e
+                );
+                return;
             }
         }
+
+        self.torrent_ids.write().await.remove(gid);
     }
 
     pub async fn pause_all(&self) {
@@ -2873,6 +2890,7 @@ mod tests {
             tasks: Arc::new(RwLock::new(tasks)),
             active_downloads: Arc::new(RwLock::new(HashMap::new())),
             torrent_ids: Arc::new(RwLock::new(HashMap::new())),
+            purged_hashes: Arc::new(RwLock::new(HashSet::new())),
             options: Arc::new(RwLock::new(options)),
             events,
             session,

--- a/src-tauri/risuko-engine/src/engine/manager.rs
+++ b/src-tauri/risuko-engine/src/engine/manager.rs
@@ -88,7 +88,15 @@ impl TaskManager {
         let session = SessionManager::new(config_dir);
         let mut saved_tasks = session.load();
 
+        let mut purged_hashes: std::collections::HashSet<String> = std::collections::HashSet::new();
         if options.purge_record_on_start() {
+            for task in saved_tasks.iter() {
+                if task.status.is_stopped() {
+                    if let Some(hash) = &task.info_hash {
+                        purged_hashes.insert(hash.clone());
+                    }
+                }
+            }
             saved_tasks.retain(|t| !t.status.is_stopped());
         }
 
@@ -125,7 +133,7 @@ impl TaskManager {
         };
 
         // Restore torrent_ids mapping from persisted librqbit session
-        manager.restore_torrent_mappings().await;
+        manager.restore_torrent_mappings(purged_hashes).await;
 
         Ok(manager)
     }
@@ -133,7 +141,12 @@ impl TaskManager {
     /// restarted, match persisted librqbit torrents back to saved tasks by info_hash.
     /// Any persisted librqbit torrent with no matching live task is purged from
     /// the librqbit session so it does not silently resume downloading on startup.
-    async fn restore_torrent_mappings(&self) {
+    /// purged_hashes: info_hashes of tasks removed due to purge_record_on_start;
+    /// these are preserved on disk (files kept) but records removed from librqbit.
+    async fn restore_torrent_mappings(
+        &self,
+        purged_hashes: std::collections::HashSet<String>,
+    ) {
         let te_guard = self.torrent_engine.read().await;
         let Some(ref te) = *te_guard else { return };
 
@@ -187,12 +200,15 @@ impl TaskManager {
         // Purge orphan librqbit torrents (persisted but no live Motrix task).
         // Without this, librqbit auto-resumes them on startup and writes files
         // even though the user has deleted or never had the task in Motrix.
+        // However, if the orphan came from purge_record_on_start, preserve files.
         for (librqbit_id, info_hash) in orphans {
-            match te.remove(librqbit_id, true).await {
+            let delete_files = !purged_hashes.contains(&info_hash);
+            match te.remove(librqbit_id, delete_files).await {
                 Ok(()) => log::info!(
-                    "Purged orphan persisted torrent: librqbit_id={} ({})",
+                    "Purged orphan persisted torrent: librqbit_id={} ({}) [delete_files={}]",
                     librqbit_id,
-                    info_hash
+                    info_hash,
+                    delete_files
                 ),
                 Err(e) => log::warn!(
                     "Failed to purge orphan torrent librqbit_id={} ({}): {}",

--- a/src-tauri/risuko-engine/src/engine/options.rs
+++ b/src-tauri/risuko-engine/src/engine/options.rs
@@ -489,4 +489,44 @@ mod tests {
         let opts = EngineOptions::from_config(&sys, &Map::new());
         assert!(!opts.bt_enable_lsd());
     }
+
+    #[test]
+    fn purge_record_on_start_defaults_false() {
+        let opts = EngineOptions::from_config(&Map::new(), &Map::new());
+        assert!(!opts.purge_record_on_start());
+    }
+
+    #[test]
+    fn purge_record_on_start_from_bool_value() {
+        let mut sys = Map::new();
+        sys.insert("purge-record-on-start".into(), json!(true));
+        let opts = EngineOptions::from_config(&sys, &Map::new());
+        assert!(opts.purge_record_on_start());
+
+        let mut sys = Map::new();
+        sys.insert("purge-record-on-start".into(), json!(false));
+        let opts = EngineOptions::from_config(&sys, &Map::new());
+        assert!(!opts.purge_record_on_start());
+    }
+
+    #[test]
+    fn purge_record_on_start_from_string_coercion() {
+        for (set, want) in [
+            ("true", true),
+            ("false", false),
+            ("yes", true),
+            ("no", false),
+            ("1", true),
+            ("0", false),
+        ] {
+            let mut sys = Map::new();
+            sys.insert("purge-record-on-start".into(), json!(set));
+            let opts = EngineOptions::from_config(&sys, &Map::new());
+            assert_eq!(
+                opts.purge_record_on_start(),
+                want,
+                "string value '{set}' should coerce to {want}"
+            );
+        }
+    }
 }

--- a/src-tauri/risuko-engine/src/engine/options.rs
+++ b/src-tauri/risuko-engine/src/engine/options.rs
@@ -57,6 +57,7 @@ impl EngineOptions {
             "bt-encryption-policy",
             "bt-listen-v6",
             "bt-enable-lsd",
+            "purge-record-on-start",
             "task-routing-rules",
             "file-category-dirs",
         ] {
@@ -208,6 +209,11 @@ impl EngineOptions {
     /// BEP-14 Local Service Discovery. Defaults to on
     pub fn bt_enable_lsd(&self) -> bool {
         self.get_bool("bt-enable-lsd").unwrap_or(true)
+    }
+
+    /// Purge completed/stopped download records when the engine starts
+    pub fn purge_record_on_start(&self) -> bool {
+        self.get_bool("purge-record-on-start").unwrap_or(false)
     }
 
     pub fn ed2k_servers(&self) -> Vec<String> {

--- a/src-tauri/risuko-engine/src/engine/torrent.rs
+++ b/src-tauri/risuko-engine/src/engine/torrent.rs
@@ -439,10 +439,18 @@ impl TorrentEngine {
             .map_err(|e| format!("Failed to unpause: {}", e))
     }
 
-    pub async fn remove(&self, torrent_id: usize) -> Result<(), String> {
+    /// Drop a torrent from the bt session
+    ///
+    /// `with_files = true` also wipes the on-disk payload (used by
+    /// "remove task" / orphan purge). `with_files = false` keeps files but
+    /// still releases the in-memory `by_hash` reservation, which is required
+    /// by `remove_download_result` / `purge_download_result` so re-adding
+    /// the same magnet does not short-circuit to `AlreadyManaged` and
+    /// surface as "magnet shows complete with no download" until restart
+    pub async fn remove(&self, torrent_id: usize, with_files: bool) -> Result<(), String> {
         let session = self.get_session()?;
         session
-            .delete(bt::TorrentIdOrHash::Id(torrent_id), false)
+            .delete(bt::TorrentIdOrHash::Id(torrent_id), with_files)
             .await
             .map_err(|e| format!("Failed to remove torrent: {}", e))
     }

--- a/src/renderer/components/Preference/Basic.vue
+++ b/src/renderer/components/Preference/Basic.vue
@@ -131,6 +131,17 @@
                 />
               </div>
             </div>
+            <div class="settings-row">
+              <div class="settings-row-content">
+                <span class="settings-row-title">{{ $t('preferences.purge-record-on-start') }}</span>
+              </div>
+              <div class="settings-row-action">
+                <ui-checkbox
+                  :model-value="!!form.purgeRecordOnStart"
+                  @change="(val) => setBasicBoolean('purgeRecordOnStart', val)"
+                />
+              </div>
+            </div>
           </div>
         </div>
 
@@ -666,6 +677,7 @@ const initForm = (config) => {
 		noConfirmBeforeDeleteTask,
 		openAtLogin,
 		preventSleepWhileDownloading,
+		purgeRecordOnStart,
 		resumeAllWhenAppLaunched,
 		runMode,
 		seedRatio,
@@ -721,6 +733,7 @@ const initForm = (config) => {
 			preventSleepWhileDownloading === undefined
 				? false
 				: parseBooleanConfig(preventSleepWhileDownloading),
+		purgeRecordOnStart: parseBooleanConfig(purgeRecordOnStart),
 		resumeAllWhenAppLaunched: parseBooleanConfig(resumeAllWhenAppLaunched),
 		runMode,
 		seedRatio,
@@ -985,6 +998,7 @@ export default {
 				"openAtLogin",
 				"keepWindowState",
 				"resumeAllWhenAppLaunched",
+				"purgeRecordOnStart",
 				"btSaveMetadata",
 				"btForceEncryption",
 				"keepSeeding",

--- a/src/shared/configKeys.ts
+++ b/src/shared/configKeys.ts
@@ -28,6 +28,7 @@ const userKeys = [
 	"prevent-sleep-while-downloading",
 	"protocols",
 	"proxy",
+	"purge-record-on-start",
 	"resume-all-when-app-launched",
 	"run-mode",
 	"show-progress-bar",

--- a/src/shared/locales/en-US/preferences.ts
+++ b/src/shared/locales/en-US/preferences.ts
@@ -92,6 +92,7 @@ export default {
 	"prevent-sleep-while-downloading-tips":
 		"Keep the computer awake whenever an active task is in progress",
 	"auto-purge-record": "Automatically purge download records when exiting app",
+	"purge-record-on-start": "Purge download records when app starts",
 	ui: "UI",
 	appearance: "Appearance",
 	"theme-auto": "Auto",

--- a/src/shared/locales/zh-CN/preferences.ts
+++ b/src/shared/locales/zh-CN/preferences.ts
@@ -87,6 +87,7 @@ export default {
 	"prevent-sleep-while-downloading": "下载时阻止系统休眠",
 	"prevent-sleep-while-downloading-tips": "存在活动任务时保持电脑唤醒",
 	"auto-purge-record": "当应用退出时自动清除下载记录",
+	"purge-record-on-start": "当应用启动时清除下载记录",
 	ui: "界面",
 	appearance: "外观",
 	"theme-auto": "自动",

--- a/src/shared/types/config.ts
+++ b/src/shared/types/config.ts
@@ -61,6 +61,7 @@ export interface AppConfig {
 	};
 	openAtLogin?: boolean;
 	preventSleepWhileDownloading?: boolean;
+	purgeRecordOnStart?: boolean;
 	autoDetectLowSpeedTasks?: boolean;
 	lowSpeedThreshold?: number;
 	lowSpeedStrikeThreshold?: number;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves BitTorrent performance by reclaiming dead/snubbed peers to prevent long‑run speed drops. Adds a startup toggle to purge stopped tasks and fixes BT session cleanup so re‑adding the same magnet works instead of showing “already managed/completed”.

- **Bug Fixes**
  - Evict silent peers after 180s and long‑snubbed peers after 60s; refresh liveness on every message and free bitfields/requests to recycle slots.
  - Drop BT session entries when removing/purging stopped torrents and during orphan cleanup on startup; history‑only removals keep files; `TorrentEngine.remove(tid, with_files)` controls deletion.

- **New Features**
  - Preferences → Basic: “Purge download records when app starts” (`purge-record-on-start`, default `false`); when enabled, the engine filters stopped tasks at boot and purges matching orphans without deleting files.
  - Issue templates now require logs to improve bug triage.

<sup>Written for commit a15815535ef00be47e5f961a0cafde89a7de414f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Purge download records on start" preference with UI toggle, tests and multi-language support
  * Updated bug report templates (EN + CN) to require validation logs and provide guidance for capturing them

* **Bug Fixes**
  * Added peer-liveness eviction to remove idle/unresponsive peers
  * Improved session cleanup to avoid stale torrent entries persisting across restarts

* **Refactor**
  * Torrent removal now supports optional deletion of on-disk files

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/YueMiyuki/Risuko/pull/71)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->