### PR TITLE
Add subfolder toggle for BT tasks

### DIFF
--- a/src-tauri/risuko-bt/src/session.rs
+++ b/src-tauri/risuko-bt/src/session.rs
@@ -557,17 +557,26 @@ impl Session {
         // (the torrent loop owns storage and will drop it on Stop).
         let file_paths: Option<Vec<(PathBuf, bool)>> = if with_files {
             let create_subfolder = handle.create_subfolder;
+            // Use the torrent's resolved root_dir (which honors a per-torrent
+            // `opts.output_folder` override) rather than the session-wide
+            // `output_dir`. For grouped multi-file layouts this root already
+            // points at `<output>/<name>/`; for flat / single-file it points
+            // at the parent directory.
+            let root = handle.root_dir.clone();
             handle
                 .with_metadata(|meta| {
-                    let root = self.output_dir.clone();
-                    if meta.info.single_file_mode {
-                        // Single-file: files live directly under root
+                    let name_empty = meta.info.name.is_empty();
+                    if meta.info.single_file_mode && !name_empty {
+                        // Single-file: file lives directly under root
                         vec![(root.join(&meta.info.name), false)]
-                    } else if create_subfolder {
-                        // Multi-file grouped: everything under root/<name>/
-                        vec![(root.join(&meta.info.name), true)]
+                    } else if !meta.info.single_file_mode && create_subfolder && !name_empty {
+                        // Multi-file grouped: root_dir IS the torrent folder,
+                        // safe to remove wholesale.
+                        vec![(root, true)]
                     } else {
-                        // Enumerate per-file paths under root
+                        // Flat layout, or any case with an empty torrent
+                        // name (defensive): enumerate per-file paths under
+                        // root so we never `remove_dir_all` the parent.
                         meta.info
                             .iter_file_details()
                             .map(|f| {

--- a/src-tauri/risuko-bt/src/session.rs
+++ b/src-tauri/risuko-bt/src/session.rs
@@ -74,13 +74,31 @@ pub struct SessionOptions {
     pub encryption: super::peer::EncryptionPolicy,
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct AddTorrentOptions {
     pub output_folder: Option<String>,
     pub overwrite: bool,
     pub trackers: Option<Vec<String>>,
     pub only_files: Option<Vec<usize>>,
     pub list_only: bool,
+    /// When `true` (default), multi-file torrents are placed inside a
+    /// subfolder named after the torrent (`<output>/<name>/...`). When
+    /// `false`, files are written directly under the output folder
+    /// Single-file torrents are unaffected
+    pub create_subfolder: bool,
+}
+
+impl Default for AddTorrentOptions {
+    fn default() -> Self {
+        Self {
+            output_folder: None,
+            overwrite: false,
+            trackers: None,
+            only_files: None,
+            list_only: false,
+            create_subfolder: true,
+        }
+    }
 }
 
 pub enum AddTorrent {
@@ -412,9 +430,12 @@ impl Session {
             .output_folder
             .map(PathBuf::from)
             .unwrap_or_else(|| self.output_dir.clone());
-        // For multi-file torrents, files are laid out under <output>/<name>/.
-        // Single-file torrents store the file directly under <output>/.
-        let root_dir = if info.single_file_mode {
+        // For multi-file torrents, files are laid out under <output>/<name>/
+        // when `create_subfolder` is set (default). When unset, files are
+        // placed directly under <output>/. Single-file torrents always
+        // store the file directly under <output>/.
+        let create_subfolder = opts.create_subfolder;
+        let root_dir = if info.single_file_mode || !create_subfolder {
             root_dir
         } else {
             root_dir.join(&info.name)
@@ -460,6 +481,7 @@ impl Session {
             max_peers: self.opts.max_peers_per_torrent,
             encryption: self.opts.encryption,
             verifier,
+            create_subfolder,
         };
         let handle = match spawn_torrent(id, init, self.peer_id, self.listen_port).await {
             Ok(h) => h,
@@ -534,15 +556,28 @@ impl Session {
         // Capture file paths for optional deletion before stopping the torrent
         // (the torrent loop owns storage and will drop it on Stop).
         let file_paths: Option<Vec<(PathBuf, bool)>> = if with_files {
+            let create_subfolder = handle.create_subfolder;
             handle
                 .with_metadata(|meta| {
                     let root = self.output_dir.clone();
                     if meta.info.single_file_mode {
                         // Single-file: files live directly under root
                         vec![(root.join(&meta.info.name), false)]
-                    } else {
-                        // Multi-file: everything under root/<name>/
+                    } else if create_subfolder {
+                        // Multi-file grouped: everything under root/<name>/
                         vec![(root.join(&meta.info.name), true)]
+                    } else {
+                        // Enumerate per-file paths under root
+                        meta.info
+                            .iter_file_details()
+                            .map(|f| {
+                                let mut p = root.clone();
+                                for c in f.filename.split('/') {
+                                    p.push(c);
+                                }
+                                (p, false)
+                            })
+                            .collect()
                     }
                 })
                 .ok()

--- a/src-tauri/risuko-bt/src/torrent.rs
+++ b/src-tauri/risuko-bt/src/torrent.rs
@@ -137,6 +137,13 @@ pub struct ManagedTorrent {
     /// Mirror of `TorrentInit::create_subfolder` so `Session::delete`
     /// can decide whether the on-disk layout is grouped or flat.
     pub create_subfolder: bool,
+    /// Resolved per-torrent root directory: the folder that directly
+    /// contains the torrent's files on disk. For multi-file grouped
+    /// layouts this already includes the torrent name. Mirrors
+    /// `TorrentInit::root_dir` so `Session::delete(with_files=true)`
+    /// can target the actual output location rather than the session
+    /// default `output_dir` (per-torrent `opts.output_folder` overrides).
+    pub root_dir: PathBuf,
     pub(crate) cmd_tx: mpsc::Sender<TorrentCommand>,
     pub(crate) stats: Arc<Mutex<TorrentStats>>,
 }
@@ -199,6 +206,7 @@ pub async fn spawn(
         name,
         metadata: metadata_swap,
         create_subfolder: init.create_subfolder,
+        root_dir: init.root_dir.clone(),
         cmd_tx,
         stats: stats.clone(),
     });

--- a/src-tauri/risuko-bt/src/torrent.rs
+++ b/src-tauri/risuko-bt/src/torrent.rs
@@ -109,6 +109,11 @@ pub struct TorrentInit {
     /// and pure-v1 torrents use SHA-1; pure-v2 torrents use SHA-256
     /// Merkle subtree verification
     pub verifier: PieceVerifier,
+    /// Whether multi-file torrents are wrapped in a `<root>/<name>/`
+    /// subfolder (the BitTorrent default). When `false`, files are
+    /// written directly under `root_dir`. Carried on `ManagedTorrent`
+    /// so `Session::delete(with_files=true)` can locate the right paths
+    pub create_subfolder: bool,
 }
 
 #[derive(Debug)]
@@ -129,6 +134,9 @@ pub struct ManagedTorrent {
     pub info_hash: Id20,
     pub name: Option<String>,
     pub metadata: ArcSwapOption<TorrentMeta>,
+    /// Mirror of `TorrentInit::create_subfolder` so `Session::delete`
+    /// can decide whether the on-disk layout is grouped or flat.
+    pub create_subfolder: bool,
     pub(crate) cmd_tx: mpsc::Sender<TorrentCommand>,
     pub(crate) stats: Arc<Mutex<TorrentStats>>,
 }
@@ -190,6 +198,7 @@ pub async fn spawn(
         info_hash,
         name,
         metadata: metadata_swap,
+        create_subfolder: init.create_subfolder,
         cmd_tx,
         stats: stats.clone(),
     });

--- a/src-tauri/risuko-engine/src/config/defaults.rs
+++ b/src-tauri/risuko-engine/src/config/defaults.rs
@@ -17,6 +17,7 @@ pub fn system_defaults() -> Map<String, Value> {
     m.insert("bt-force-encryption".into(), json!(false));
     m.insert("bt-load-saved-metadata".into(), json!(true));
     m.insert("bt-save-metadata".into(), json!(true));
+    m.insert("bt-create-subfolder".into(), json!(true));
     m.insert("bt-tracker".into(), json!(""));
     m.insert("bt-max-peers-per-torrent".into(), json!(100));
     m.insert("bt-max-outstanding-per-peer".into(), json!(128));

--- a/src-tauri/risuko-engine/src/engine/manager.rs
+++ b/src-tauri/risuko-engine/src/engine/manager.rs
@@ -1840,13 +1840,19 @@ impl TaskManager {
                             // Populate file list from torrent metadata
                             if let Some(ref file_details) = stats.file_details {
                                 let torrent_name = task.bt_name.as_deref().unwrap_or("");
-                                let base_dir = if torrent_name.is_empty() {
+                                let create_subfolder = task
+                                    .options
+                                    .get("bt-create-subfolder")
+                                    .and_then(|v| v.as_bool())
+                                    .unwrap_or(true);
+                                let base_dir = if torrent_name.is_empty()
+                                    || file_details.len() <= 1
+                                    || !create_subfolder
+                                {
                                     task.dir.clone()
-                                } else if file_details.len() > 1 {
-                                    // Multi-file: files are inside torrent folder
-                                    format!("{}/{}", task.dir, torrent_name)
                                 } else {
-                                    task.dir.clone()
+                                    // Multi-file grouped: files are inside torrent folder
+                                    format!("{}/{}", task.dir, torrent_name)
                                 };
 
                                 // Determine which files are selected (0-based indices)

--- a/src-tauri/risuko-engine/src/engine/manager.rs
+++ b/src-tauri/risuko-engine/src/engine/manager.rs
@@ -1762,7 +1762,7 @@ impl TaskManager {
             // Update torrent tasks
             let te_guard = self.torrent_engine.read().await;
             let tid_guard = self.torrent_ids.read().await;
-            let (keep_seeding, seed_time_minutes, seed_ratio) = {
+            let (keep_seeding, seed_time_minutes, seed_ratio, bt_create_subfolder_default) = {
                 let opts = self.options.read().await;
                 let st = opts.seed_time();
                 let ratio = opts.seed_ratio();
@@ -1775,7 +1775,11 @@ impl TaskManager {
                 let keep = manual || st > 0 || ratio > 0.0;
                 let effective_time = if manual { 0 } else { st };
                 let effective_ratio = if manual { 0.0 } else { ratio };
-                (keep, effective_time, effective_ratio)
+                // Capture the global default so per-task missing values fall
+                // back to it instead of hard-coded `true`, which previously
+                // ignored a user-configured `bt-create-subfolder=false`.
+                let csub_default = opts.get_bool("bt-create-subfolder").unwrap_or(true);
+                (keep, effective_time, effective_ratio, csub_default)
             };
             if let Some(ref te) = *te_guard {
                 for task in tasks.iter_mut() {
@@ -1844,7 +1848,7 @@ impl TaskManager {
                                     .options
                                     .get("bt-create-subfolder")
                                     .and_then(|v| v.as_bool())
-                                    .unwrap_or(true);
+                                    .unwrap_or(bt_create_subfolder_default);
                                 let base_dir = if torrent_name.is_empty()
                                     || file_details.len() <= 1
                                     || !create_subfolder

--- a/src-tauri/risuko-engine/src/engine/manager.rs
+++ b/src-tauri/risuko-engine/src/engine/manager.rs
@@ -1849,8 +1849,12 @@ impl TaskManager {
                                     .get("bt-create-subfolder")
                                     .and_then(|v| v.as_bool())
                                     .unwrap_or(bt_create_subfolder_default);
-                                let base_dir = if torrent_name.is_empty()
-                                    || file_details.len() <= 1
+                                let base_dir = if let Some(resolved_root) =
+                                    stats.resolved_root.as_ref().filter(|s| !s.is_empty())
+                                {
+                                    resolved_root.clone()
+                                } else if torrent_name.is_empty()
+                                    || stats.single_file_mode
                                     || !create_subfolder
                                 {
                                     task.dir.clone()

--- a/src-tauri/risuko-engine/src/engine/torrent.rs
+++ b/src-tauri/risuko-engine/src/engine/torrent.rs
@@ -409,6 +409,10 @@ impl TorrentEngine {
         let file_details = metadata_payload
             .as_ref()
             .map(|meta| extract_file_details(&meta.info));
+        let single_file_mode = metadata_payload
+            .as_ref()
+            .map(|meta| meta.info.single_file_mode)
+            .unwrap_or(false);
 
         Some(TorrentStats {
             total_bytes: stats.total_bytes,
@@ -422,6 +426,8 @@ impl TorrentEngine {
             name,
             file_progress: stats.file_progress,
             file_details,
+            resolved_root: Some(handle.root_dir.to_string_lossy().into_owned()),
+            single_file_mode,
             peers,
             metadata,
         })
@@ -541,6 +547,8 @@ pub struct TorrentStats {
     pub name: Option<String>,
     pub file_progress: Vec<u64>,
     pub file_details: Option<Vec<TorrentFileInfo>>,
+    pub resolved_root: Option<String>,
+    pub single_file_mode: bool,
     pub peers: Vec<PeerSnapshot>,
     pub metadata: Option<TorrentMetadataInfo>,
 }

--- a/src-tauri/risuko-engine/src/engine/torrent.rs
+++ b/src-tauri/risuko-engine/src/engine/torrent.rs
@@ -156,6 +156,10 @@ impl TorrentEngine {
 
         let trackers = Self::parse_trackers(options);
         let only_files = Self::parse_select_files(options);
+        let create_subfolder = options
+            .get("bt-create-subfolder")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
 
         let add_opts = bt::AddTorrentOptions {
             output_folder: Some(dir.to_string()),
@@ -167,6 +171,7 @@ impl TorrentEngine {
             },
             only_files,
             list_only: false,
+            create_subfolder,
         };
 
         log::info!("Adding torrent bytes ({} bytes) to dir={}", data.len(), dir);
@@ -202,6 +207,10 @@ impl TorrentEngine {
 
         let trackers = Self::parse_trackers(options);
         let only_files = Self::parse_select_files(options);
+        let create_subfolder = options
+            .get("bt-create-subfolder")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
 
         let add_opts = bt::AddTorrentOptions {
             output_folder: Some(dir.to_string()),
@@ -213,6 +222,7 @@ impl TorrentEngine {
             },
             only_files,
             list_only: false,
+            create_subfolder,
         };
 
         log::info!("Adding magnet to dir={}: {}", dir, magnet_uri);

--- a/src/renderer/components/Preference/Advanced.vue
+++ b/src/renderer/components/Preference/Advanced.vue
@@ -406,6 +406,23 @@
             <div class="settings-row" style="margin-top: 8px">
               <div class="settings-row-content">
                 <div class="settings-row-title">
+                  {{ $t('preferences.bt-create-subfolder') }}
+                </div>
+                <div class="settings-row-description">
+                  {{ $t('preferences.bt-create-subfolder-tips') }}
+                </div>
+              </div>
+              <div class="settings-row-action">
+                <ui-checkbox
+                  :model-value="!!form.btCreateSubfolder"
+                  @change="(val) => setAdvancedBoolean('btCreateSubfolder', val)"
+                />
+              </div>
+            </div>
+
+            <div class="settings-row" style="margin-top: 8px">
+              <div class="settings-row-content">
+                <div class="settings-row-title">
                   {{ $t('preferences.bt-encryption-policy') }}
                 </div>
                 <div class="settings-row-description">
@@ -1205,6 +1222,7 @@ const initForm = (config) => {
 		btEnableUpnp,
 		btUpnpLease,
 		btEnableLsd,
+		btCreateSubfolder,
 		btEncryptionPolicy,
 		btListenV6,
 		connectTimeout,
@@ -1255,6 +1273,7 @@ const initForm = (config) => {
 		btEnableUpnp: parseBooleanConfig(btEnableUpnp, true),
 		btUpnpLease: btUpnpLease ?? 300,
 		btEnableLsd: parseBooleanConfig(btEnableLsd, true),
+		btCreateSubfolder: parseBooleanConfig(btCreateSubfolder, true),
 		btEncryptionPolicy: btEncryptionPolicy || "prefer",
 		btListenV6: parseBooleanConfig(btListenV6, false),
 		connectTimeout: connectTimeout ?? 60,

--- a/src/shared/configKeys.ts
+++ b/src/shared/configKeys.ts
@@ -58,6 +58,7 @@ const systemKeys = [
 	"bt-force-encryption",
 	"bt-load-saved-metadata",
 	"bt-save-metadata",
+	"bt-create-subfolder",
 	"bt-tracker",
 	"bt-max-peers-per-torrent",
 	"bt-max-outstanding-per-peer",

--- a/src/shared/locales/en-US/preferences.ts
+++ b/src/shared/locales/en-US/preferences.ts
@@ -36,6 +36,9 @@ export default {
 	"transfer-speed-unlimited": "Unlimited",
 	"bt-settings": "BitTorrent",
 	"bt-save-metadata": "Save magnet link as torrent file",
+	"bt-create-subfolder": "Group multi-file torrents into a subfolder",
+	"bt-create-subfolder-tips":
+		"When enabled, multi-file BitTorrent and magnet downloads are placed inside a folder named after the torrent. When disabled, the files are written directly into the download directory.",
 	"bt-auto-download-content":
 		"Automatically download magnet and torrent content",
 	"bt-force-encryption": "BT force encryption",

--- a/src/shared/locales/zh-CN/preferences.ts
+++ b/src/shared/locales/zh-CN/preferences.ts
@@ -36,6 +36,9 @@ export default {
 	"transfer-speed-unlimited": "不限速",
 	"bt-settings": "BT 设置",
 	"bt-save-metadata": "保存磁力链接元数据为种子文件",
+	"bt-create-subfolder": "多文件种子下载到独立子文件夹",
+	"bt-create-subfolder-tips":
+		"启用后，多文件的 BT 与磁力下载会被放入以种子名称命名的文件夹中；关闭则直接保存到下载目录。",
 	"bt-auto-download-content": "自动开始下载磁力链接、种子的文件",
 	"bt-force-encryption": "BT强制加密",
 	"keep-seeding": "持续做种，直到手动停止",

--- a/src/shared/types/config.ts
+++ b/src/shared/types/config.ts
@@ -40,6 +40,7 @@ export interface AppConfig {
 	autoSyncTracker?: boolean;
 	trackerSource?: string[];
 	btTracker?: string;
+	btCreateSubfolder?: boolean;
 	lastSyncTrackerTime?: number;
 	maxOverallDownloadLimit?: number;
 	maxOverallUploadLimit?: number;


### PR DESCRIPTION
#72 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a toggle to group multi-file BitTorrent downloads into a subfolder, default on. Users can choose between `<download>/<torrent-name>/...` and a flat layout.

- New Features
  - Added `bt-create-subfolder` (default true) with a checkbox in Preferences → Advanced; saved in config defaults, wired through config keys/types, and added i18n for en-US and zh-CN.
  - Engine/BT honor `create_subfolder` for .torrent and magnet adds; compute and carry per-torrent `root_dir`; expose `resolved_root` and `single_file_mode` in stats; deletion and task file listing use these values and fall back to the global default when a per-task value is missing.

<sup>Written for commit 3c19a53daf8bdc2778fd5df3d1d39f5f4f574fb1. Summary will update on new commits. <a href="https://cubic.dev/pr/YueMiyuki/Risuko/pull/74?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Advanced preference to control whether multi-file torrents are placed in a subfolder (enabled by default).
  * Torrent details/stats now surface resolved download root and single-file mode.

* **Bug Fixes**
  * Adding and deleting torrents now follow the chosen subfolder/flat layout so files are placed and removed consistently.

* **Localization**
  * Added UI label and tooltip for the new preference.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/YueMiyuki/Risuko/pull/74?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->