### PR TITLE
fix(engine): skip low-speed pause/resume recovery for swarm protocols

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1_bug_report.yml
@@ -75,7 +75,7 @@ body:
           required: true
         - label: The provided reproduction is a [minimal reproducible](https://stackoverflow.com/help/minimal-reproducible-example) of the bug.
           required: true
-        - label: You have tried with test URL (https://cdn.hotelnearmedanta.com/testfile.org/testfile.org-5GB.dat) and the bug still occurs.
+        - label: You have tried with test URL https://cdn.hotelnearmedanta.com/testfile.org/testfile.org-5GB.dat and the bug still occurs.
           required: true
         - label: You have provided logs (In Preference - Advanced - Log level set to Debug, Reproduce the error and find log file by clicking "Open log file" in the same page)
           required: true

--- a/.github/ISSUE_TEMPLATE/1_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1_bug_report.yml
@@ -75,7 +75,7 @@ body:
           required: true
         - label: The provided reproduction is a [minimal reproducible](https://stackoverflow.com/help/minimal-reproducible-example) of the bug.
           required: true
-        - label: You have tried with test URL https://cdn.hotelnearmedanta.com/testfile.org/testfile.org-5GB.dat and the bug still occurs.
+        - label: You have tried with test URL (https://cdn.hotelnearmedanta.com/testfile.org/testfile.org-5GB.dat) and the bug still occurs.
           required: true
         - label: You have provided logs (In Preference - Advanced - Log level set to Debug, Reproduce the error and find log file by clicking "Open log file" in the same page)
           required: true

--- a/.github/ISSUE_TEMPLATE/2_bug_report_cn.yml
+++ b/.github/ISSUE_TEMPLATE/2_bug_report_cn.yml
@@ -75,7 +75,7 @@ body:
           required: true
         - label: 提供的复现是该 Bug 的 [最小复现例子](https://stackoverflow.com/help/minimal-reproducible-example)。
           required: true
-        - label: 您已经尝试使用测试 URL (https://cdn.hotelnearmedanta.com/testfile.org/testfile.org-5GB.dat) 并且该 Bug 仍然存在。
+        - label: 您已经尝试使用测试 URL https://cdn.hotelnearmedanta.com/testfile.org/testfile.org-5GB.dat 并且该 Bug 仍然存在。
           required: true
         - label: 您已经提供了日志（在首选项 → 进阶设置 → 应用日志路径，或在健康检查 → 工具 → 打开日志目录）
           required: true

--- a/.github/ISSUE_TEMPLATE/2_bug_report_cn.yml
+++ b/.github/ISSUE_TEMPLATE/2_bug_report_cn.yml
@@ -75,7 +75,7 @@ body:
           required: true
         - label: 提供的复现是该 Bug 的 [最小复现例子](https://stackoverflow.com/help/minimal-reproducible-example)。
           required: true
-        - label: 您已经尝试使用测试 URL https://cdn.hotelnearmedanta.com/testfile.org/testfile.org-5GB.dat，并且该 Bug 仍然存在。
+        - label: 您已经尝试使用测试 URL (https://cdn.hotelnearmedanta.com/testfile.org/testfile.org-5GB.dat) 并且该 Bug 仍然存在。
           required: true
         - label: 您已经提供了日志（在首选项 → 进阶设置 → 应用日志路径，或在健康检查 → 工具 → 打开日志目录）
           required: true

--- a/src-tauri/risuko-engine/src/engine/manager.rs
+++ b/src-tauri/risuko-engine/src/engine/manager.rs
@@ -149,7 +149,9 @@ impl TaskManager {
     /// purge provenance stays on the manager until this cleanup completes successfully.
     async fn restore_torrent_mappings(&self) -> bool {
         let te_guard = self.torrent_engine.read().await;
-        let Some(ref te) = *te_guard else { return false };
+        let Some(ref te) = *te_guard else {
+            return false;
+        };
 
         let purged_hashes = self.purged_hashes.read().await.clone();
 

--- a/src-tauri/risuko-engine/src/engine/task.rs
+++ b/src-tauri/risuko-engine/src/engine/task.rs
@@ -659,6 +659,13 @@ impl DownloadTask {
             "status".into(),
             Value::String(self.status.as_str().to_string()),
         );
+        // Lowercase task kind (http/ftp/torrent/ed2k/m3u8/youtube/adc/gnutella/g2/gift).
+        // Surfaces protocol family to the frontend so policy decisions (e.g. skipping
+        // peer-swarm tasks from low-speed pause/resume recovery) don't have to infer
+        // it from optional sentinel fields
+        if let Ok(Value::String(kind)) = serde_json::to_value(self.kind) {
+            m.insert("kind".into(), Value::String(kind));
+        }
         m.insert(
             "totalLength".into(),
             Value::String(self.total_length.to_string()),

--- a/src/renderer/components/Native/EngineClient.vue
+++ b/src/renderer/components/Native/EngineClient.vue
@@ -4,7 +4,12 @@
 
 <script lang="ts">
 import type { DownloadTask } from "@shared/types/task";
-import { checkTaskIsBT, getTaskName, parseBooleanConfig } from "@shared/utils";
+import {
+	checkTaskIsBT,
+	getTaskName,
+	parseBooleanConfig,
+	taskBenefitsFromLowSpeedRecovery,
+} from "@shared/utils";
 import logger from "@shared/utils/logger";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
@@ -381,16 +386,37 @@ export default {
 		async handleLowSpeedTasks(
 			tasks: Pick<
 				DownloadTask,
-				"gid" | "status" | "downloadSpeed" | "seeder"
+				| "gid"
+				| "status"
+				| "downloadSpeed"
+				| "seeder"
+				| "bittorrent"
+				| "ed2kLink"
+				| "kind"
 			>[] = [],
 		) {
 			if (!this.autoDetectLowSpeedTasks) {
 				return;
 			}
 
+			// Pause/resume only revives a stalled single TCP socket. Peer-swarm
+			// tasks (BT/ED2K/ADC/Gnutella/G2/giFT) take minutes to warm up and a
+			// force-pause aborts that warm-up; the cooldown then refires before
+			// the swarm can rebuild, leaving speed permanently at zero. Filter
+			// down to kinds that actually benefit before consulting the evaluator
+			const eligibleTasks = tasks.filter((task) =>
+				taskBenefitsFromLowSpeedRecovery(task),
+			);
+			if (!eligibleTasks.length) {
+				this.lowSpeedStrikeMap = {};
+				this.lowSpeedRecoverAtMap = {};
+				this.syncLowSpeedRecoveringMapWithState();
+				return;
+			}
+
 			try {
 				const result = await api.evaluateLowSpeedTasks({
-					tasks: tasks.map((task) => {
+					tasks: eligibleTasks.map((task) => {
 						const isSeedingTask =
 							task?.seeder === "true" || String(task?.seeder) === "true";
 						return {
@@ -836,7 +862,13 @@ export default {
 				];
 				let activeTasksForLowSpeedCheck: Pick<
 					DownloadTask,
-					"gid" | "status" | "downloadSpeed" | "seeder"
+					| "gid"
+					| "status"
+					| "downloadSpeed"
+					| "seeder"
+					| "bittorrent"
+					| "ed2kLink"
+					| "kind"
 				>[] = [];
 
 				if (!document.hidden || this.taskDetailVisible) {
@@ -847,7 +879,15 @@ export default {
 					jobs.push(
 						api
 							.fetchActiveTaskList({
-								keys: ["gid", "status", "downloadSpeed", "seeder"],
+								keys: [
+									"gid",
+									"status",
+									"downloadSpeed",
+									"seeder",
+									"bittorrent",
+									"ed2kLink",
+									"kind",
+								],
 							})
 							.then((tasks) => {
 								activeTasksForLowSpeedCheck = Array.isArray(tasks) ? tasks : [];

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -426,6 +426,40 @@ export const checkTaskIsBT = (task: Partial<DownloadTask> = {}) => {
 	return !!bittorrent;
 };
 
+// Task kinds (engine-side `TaskKind`, lowercase) where force-pause + resume
+// is a useful recovery for a stalled connection: a single TCP socket gets
+// stuck and reopening it kicks the download free. HTTP/HTTPS, FTP/SFTP
+// (both folded into `ftp`), HTTP-segment streams (`youtube`, `m3u8`) all
+// fit that mould
+//
+// Peer-swarm protocols (`torrent`, `ed2k`, `adc`, `gnutella`, `g2`, `gift`)
+// do NOT fit. Pause tears down peer connections, aborts in-flight tracker
+// announces and choke-unchoke negotiations; the swarm just spent minutes
+// warming up and is wiped in 500 ms. The recovery cooldown then refires
+// before the swarm can rebuild, leaving speed permanently at zero
+const LOW_SPEED_RECOVERABLE_KINDS = new Set(["http", "ftp", "youtube", "m3u8"]);
+
+export const taskBenefitsFromLowSpeedRecovery = (
+	task: Partial<DownloadTask> = {},
+) => {
+	if (checkTaskIsBT(task)) {
+		return false;
+	}
+	// Defensive: legacy/unknown task shapes that lack `kind` but expose a
+	// peer-swarm sentinel field should still be excluded.
+	if (task.ed2kLink) {
+		return false;
+	}
+	const kind = `${task.kind || ""}`.toLowerCase();
+	if (!kind) {
+		// No kind reported. Without a positive signal we can't tell whether
+		// pause/resume is safe, so opt out — losing recovery on an HTTP task
+		// is harmless, while applying it to a swarm task is destructive.
+		return false;
+	}
+	return LOW_SPEED_RECOVERABLE_KINDS.has(kind);
+};
+
 const changeKeysCase = (obj, caseConverter) => {
 	const result = {};
 	if (isEmpty(obj) || !isFunction(caseConverter)) {


### PR DESCRIPTION
#75 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip low-speed auto pause/resume for swarm protocols (BT, ED2K, ADC, Gnutella, G2, giFT) to prevent stall loops. Apply recovery only to single-connection tasks (HTTP/FTP/M3U8/YouTube) using the new task `kind`.

- **Bug Fixes**
  - Engine/Utils: add lowercase `kind` to task JSON; add `taskBenefitsFromLowSpeedRecovery` (recoverable: `http`, `ftp`, `youtube`, `m3u8`); keep early return if torrent engine is missing.
  - UI: `EngineClient.vue` fetches `bittorrent`/`ed2kLink`/`kind`, only evaluates eligible tasks, and clears recovery maps when none qualify.
  - Templates: tweak CN bug report test URL text.

<sup>Written for commit c783d01ec01228c79a45d1cc9f4b66d9e17a3df6. Summary will update on new commits. <a href="https://cubic.dev/pr/YueMiyuki/Risuko/pull/76?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved low-speed task recovery mechanism to selectively handle only eligible protocol types (HTTP, FTP, YouTube, m3u8), excluding BitTorrent and ed2k tasks from recovery attempts.

* **Chores**
  * Updated issue templates with improved formatting.
  * Code style improvements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/YueMiyuki/Risuko/pull/76?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->