### PR TITLE
feat(task): support per-link Rename directives in URI input

### DIFF
--- a/src/renderer/components/Task/AddTask.vue
+++ b/src/renderer/components/Task/AddTask.vue
@@ -284,7 +284,11 @@ import {
 	NONE_SELECTED_FILES,
 	SELECTED_ALL_FILES,
 } from "@shared/constants";
-import { detectUriProtocol, splitTaskLinks } from "@shared/utils";
+import {
+	detectUriProtocol,
+	splitTaskLinks,
+	splitTaskLinksWithRenames,
+} from "@shared/utils";
 import logger from "@shared/utils/logger";
 import { readText } from "@tauri-apps/plugin-clipboard-manager";
 import { open as tauriOpen } from "@tauri-apps/plugin-dialog";
@@ -592,13 +596,19 @@ export default {
 		},
 		commitUriDraft() {
 			const text = this.uriDraft || "";
-			const links = splitTaskLinks(text);
-			if (links.length === 0) {
+			const parsed = splitTaskLinksWithRenames(text);
+			if (parsed.length === 0) {
 				return;
 			}
-			const items = links.map((u) => createUriBatchItem(u));
+			const items = parsed.map(({ uri, rename }) => {
+				const item = createUriBatchItem(uri);
+				if (rename) {
+					item.out = rename;
+				}
+				return item;
+			});
 			useAppStore().enqueueBatchItems(items);
-			this.notifyDetectedProtocols(links);
+			this.notifyDetectedProtocols(parsed.map((p) => p.uri));
 			this.uriDraft = "";
 		},
 		notifyDetectedProtocols(links: string[]) {

--- a/src/renderer/utils/task.ts
+++ b/src/renderer/utils/task.ts
@@ -5,7 +5,11 @@ import {
 } from "@shared/constants";
 import type { AppConfig } from "@shared/types/config";
 import type { SavedCredential } from "@shared/types/credential";
-import { isFtpFamily, isSftpLink, splitTaskLinks } from "@shared/utils";
+import {
+	isFtpFamily,
+	isSftpLink,
+	splitTaskLinksWithRenames,
+} from "@shared/utils";
 import {
 	buildDefaultOptionsFromCurl,
 	buildHeadersFromCurl,
@@ -204,10 +208,16 @@ export const buildUriPayload = async (form: TaskForm) => {
 		throw new Error("task.new-task-uris-required");
 	}
 
-	let uriList = splitTaskLinks(rawUris);
+	const parsedLines = splitTaskLinksWithRenames(rawUris);
+	let uriList = parsedLines.map((p) => p.uri);
 	const curlHeaders = buildHeadersFromCurl(uriList);
 	uriList = buildUrisFromCurl(uriList);
-	const outs = buildOuts(uriList, out);
+	const formOuts = buildOuts(uriList, out);
+	// Per-line `Rename:` directives win over the form-level out; otherwise
+	// fall back to the form-level value (with index-rule expansion)
+	const outs = uriList.map(
+		(_, i) => parsedLines[i]?.rename || formOuts[i] || "",
+	);
 
 	const resolvedForm: TaskForm = buildDefaultOptionsFromCurl(form, curlHeaders);
 

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -584,23 +584,24 @@ export const parseRenameDirective = (line = ""): ParsedTaskLink => {
 		return { uri: line };
 	}
 	const rename = m[1].trim();
+	const uri = line.slice(0, m.index).trim();
 	// Reject path separators — `out` is a filename, never a path
 	if (!rename || rename.includes("/") || rename.includes("\\")) {
-		return { uri: line };
+		return { uri };
 	}
-	return { uri: line.slice(0, m.index).trim(), rename };
+	return { uri, rename };
 };
 
 export const splitTaskLinks = (links = "") => {
 	return compact(splitTextRows(links))
-		.map(decodeThunderLink)
-		.map((line) => parseRenameDirective(line).uri);
+		.map(parseRenameDirective)
+		.map(({ uri }) => decodeThunderLink(uri));
 };
 
 export const splitTaskLinksWithRenames = (links = ""): ParsedTaskLink[] => {
 	return compact(splitTextRows(links))
-		.map(decodeThunderLink)
-		.map(parseRenameDirective);
+		.map(parseRenameDirective)
+		.map(({ uri, rename }) => ({ uri: decodeThunderLink(uri), rename }));
 };
 
 const isFtpLink = (uri: string): boolean => {

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -567,8 +567,40 @@ const decodeThunderLink = (url = "") => {
 	return result;
 };
 
+// Trailing ` Rename: <filename>` directive on a single link line lets users
+// override the output filename per URL without filling out the form `out`
+// field. The capture is greedy to end-of-line so filenames with spaces are
+// preserved; we trim and reject path separators to keep it strictly a name
+const RENAME_SUFFIX_REGEX = /\s+Rename:\s*(\S.*?)\s*$/i;
+
+export interface ParsedTaskLink {
+	uri: string;
+	rename?: string;
+}
+
+export const parseRenameDirective = (line = ""): ParsedTaskLink => {
+	const m = RENAME_SUFFIX_REGEX.exec(line);
+	if (!m) {
+		return { uri: line };
+	}
+	const rename = m[1].trim();
+	// Reject path separators — `out` is a filename, never a path
+	if (!rename || rename.includes("/") || rename.includes("\\")) {
+		return { uri: line };
+	}
+	return { uri: line.slice(0, m.index).trim(), rename };
+};
+
 export const splitTaskLinks = (links = "") => {
-	return compact(splitTextRows(links)).map(decodeThunderLink);
+	return compact(splitTextRows(links))
+		.map(decodeThunderLink)
+		.map((line) => parseRenameDirective(line).uri);
+};
+
+export const splitTaskLinksWithRenames = (links = ""): ParsedTaskLink[] => {
+	return compact(splitTextRows(links))
+		.map(decodeThunderLink)
+		.map(parseRenameDirective);
 };
 
 const isFtpLink = (uri: string): boolean => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add per-link Rename directives in the URI input so you can set output filenames inline for each URL. Per-line values override the form’s Out field; otherwise the usual out/index expansion applies.

- New Features
  - Support trailing "Rename: <filename>" (case-insensitive) on a link line; spaces allowed; filenames only, paths rejected.
  - Added `splitTaskLinksWithRenames()` and `parseRenameDirective()`; `splitTaskLinks()` now strips the directive.
  - Integrated into Add Task and payload builder to set `item.out` per link with proper fallback; protocol detection uses cleaned URIs.

<sup>Written for commit b160176e81d68fba764fac9bb2c706150a1d7503. Summary will update on new commits. <a href="https://cubic.dev/pr/YueMiyuki/Risuko/pull/77?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Task links support per-line "Rename:" directives so you can specify custom output filenames for individual items when adding tasks.
* **Improvements**
  * Draft commit and task creation now correctly apply per-line renames to queued items and use the parsed URIs for protocol detection, improving accuracy when adding links.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/YueMiyuki/Risuko/pull/77?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->