### PR TITLE
fix: log peer handshake outcomes and fall back to config rpc-secret

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,0 +1,16 @@
+# CodeGraph data files
+# These are local to each machine and should not be committed
+
+# Database
+*.db
+*.db-wal
+*.db-shm
+
+# Cache
+cache/
+
+# Logs
+*.log
+
+# Hook markers
+.dirty

--- a/src-tauri/risuko-bt/src/peer/connection.rs
+++ b/src-tauri/risuko-bt/src/peer/connection.rs
@@ -240,7 +240,22 @@ async fn drive_handshake(
                     std::io::Error::new(std::io::ErrorKind::TimedOut, "connect timeout")
                 })??;
             stream.set_nodelay(true).ok();
-            connect_mse(stream, addr, &spawn).await
+            // Log the MSE outcome so a debug-level log captures whether the
+            // encrypted fallback ever succeeds. Without this, an operator
+            // troubleshooting "0 KB/s" only sees N "trying mse" lines and
+            // cannot tell whether (a) every peer also rejects MSE so no
+            // outbound peer ever connects, or (b) MSE works fine and the
+            // download is slow for some other reason
+            match connect_mse(stream, addr, &spawn).await {
+                Ok(v) => {
+                    log::debug!("mse handshake to {addr} succeeded");
+                    Ok(v)
+                }
+                Err(e) => {
+                    log::debug!("mse handshake to {addr} failed: {e}");
+                    Err(e)
+                }
+            }
         }
     }
 }

--- a/src-tauri/risuko-bt/src/torrent.rs
+++ b/src-tauri/risuko-bt/src/torrent.rs
@@ -833,7 +833,11 @@ async fn process_peer_event(
     // (Piece) or unblock requests (Unchoke, Bitfield, Have)
     let mut kick = false;
     match ev {
-        PeerEvent::Handshook { reserved, .. } => {
+        PeerEvent::Handshook {
+            reserved,
+            encrypted,
+            ..
+        } => {
             if !peers.contains_key(&pid) {
                 if let Some((cmd_tx, registry_addr)) = peer_registry::take(torrent_id, pid) {
                     // Move from pending dial to live peer. The registry is
@@ -854,6 +858,10 @@ async fn process_peer_event(
                         let _ = cmd_tx.send(PeerCommand::Disconnect).await;
                         return false;
                     }
+                    log::debug!(
+                        "peer connected: {addr} (encrypted={encrypted}, peers={}/{max_peers})",
+                        peers.len() + 1
+                    );
                     peers.insert(
                         pid,
                         Peer {
@@ -1226,7 +1234,7 @@ async fn process_peer_event(
                 _ => {}
             }
         }
-        PeerEvent::Disconnected { .. } => {
+        PeerEvent::Disconnected { reason } => {
             // Clear from either in-flight or live, and release the address
             // for future retries (otherwise a single drop permanently
             // blacklists the peer).
@@ -1234,6 +1242,12 @@ async fn process_peer_event(
                 .remove(&pid)
                 .or_else(|| peers.get(&pid).map(|p| p.addr));
             if let Some(a) = addr {
+                // Log the disconnect cause at debug so the per-peer error —
+                // typically the MSE handshake outcome for unreachable /
+                // encryption-only peers — is visible to operators
+                // troubleshooting "0 KB/s" reports without us having to
+                // re-deduce it from "trying mse" lines alone
+                log::debug!("peer {a} disconnected: {reason}");
                 known_addrs.remove(&a);
             }
             // Drop the registry slot in case the peer disconnected before

--- a/src-tauri/risuko-cli/src/commands.rs
+++ b/src-tauri/risuko-cli/src/commands.rs
@@ -16,10 +16,27 @@ use crate::{
     RssAction, RssCommand, ServeArgs, StatusArgs,
 };
 
+/// Read rpc-secret from the config files, returning None if empty or absent.
+fn read_secret_from_config() -> Option<String> {
+    let config_dir = get_config_dir();
+    let system = load_config(&config_dir.join("system.json"), Map::new());
+    let secret = system
+        .get("rpc-secret")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    if secret.is_empty() {
+        None
+    } else {
+        Some(secret)
+    }
+}
+
 // Download
 
 pub async fn download(args: DownloadArgs) -> Result<(), Box<dyn std::error::Error>> {
-    let client = RpcClient::new(args.rpc_port, args.rpc_secret.clone());
+    let secret = args.rpc_secret.clone().or_else(read_secret_from_config);
+    let client = RpcClient::new(args.rpc_port, secret.clone());
     let mut headless_engine = None;
 
     if !client.is_engine_running().await {
@@ -136,7 +153,8 @@ async fn do_download(
 // Status
 
 pub async fn status(args: StatusArgs) -> Result<(), Box<dyn std::error::Error>> {
-    let client = RpcClient::new(args.rpc_port, args.rpc_secret.clone());
+    let secret = args.rpc_secret.clone().or_else(read_secret_from_config);
+    let client = RpcClient::new(args.rpc_port, secret);
     require_engine(&client).await?;
 
     if let Some(ref gid) = args.gid {
@@ -191,7 +209,8 @@ pub async fn status(args: StatusArgs) -> Result<(), Box<dyn std::error::Error>> 
 // Pause / Resume / Remove
 
 pub async fn pause(args: PauseArgs) -> Result<(), Box<dyn std::error::Error>> {
-    let client = RpcClient::new(args.rpc_port, args.rpc_secret.clone());
+    let secret = args.rpc_secret.clone().or_else(read_secret_from_config);
+    let client = RpcClient::new(args.rpc_port, secret);
     require_engine(&client).await?;
     client.call("risuko.pause", vec![json!(args.gid)]).await?;
     println!("Paused: {}", args.gid);
@@ -199,7 +218,8 @@ pub async fn pause(args: PauseArgs) -> Result<(), Box<dyn std::error::Error>> {
 }
 
 pub async fn resume(args: ResumeArgs) -> Result<(), Box<dyn std::error::Error>> {
-    let client = RpcClient::new(args.rpc_port, args.rpc_secret.clone());
+    let secret = args.rpc_secret.clone().or_else(read_secret_from_config);
+    let client = RpcClient::new(args.rpc_port, secret);
     require_engine(&client).await?;
     client.call("risuko.unpause", vec![json!(args.gid)]).await?;
     println!("Resumed: {}", args.gid);
@@ -207,7 +227,8 @@ pub async fn resume(args: ResumeArgs) -> Result<(), Box<dyn std::error::Error>> 
 }
 
 pub async fn remove(args: RemoveArgs) -> Result<(), Box<dyn std::error::Error>> {
-    let client = RpcClient::new(args.rpc_port, args.rpc_secret.clone());
+    let secret = args.rpc_secret.clone().or_else(read_secret_from_config);
+    let client = RpcClient::new(args.rpc_port, secret);
     require_engine(&client).await?;
     for gid in &args.gids {
         match client.call("risuko.remove", vec![json!(gid)]).await {
@@ -221,7 +242,8 @@ pub async fn remove(args: RemoveArgs) -> Result<(), Box<dyn std::error::Error>> 
 // Pause All / Resume All
 
 pub async fn pause_all(args: RpcArgs) -> Result<(), Box<dyn std::error::Error>> {
-    let client = RpcClient::new(args.rpc_port, args.rpc_secret.clone());
+    let secret = args.rpc_secret.clone().or_else(read_secret_from_config);
+    let client = RpcClient::new(args.rpc_port, secret);
     require_engine(&client).await?;
     client.call("risuko.pauseAll", vec![]).await?;
     println!("All downloads paused.");
@@ -229,7 +251,8 @@ pub async fn pause_all(args: RpcArgs) -> Result<(), Box<dyn std::error::Error>> 
 }
 
 pub async fn resume_all(args: RpcArgs) -> Result<(), Box<dyn std::error::Error>> {
-    let client = RpcClient::new(args.rpc_port, args.rpc_secret.clone());
+    let secret = args.rpc_secret.clone().or_else(read_secret_from_config);
+    let client = RpcClient::new(args.rpc_port, secret);
     require_engine(&client).await?;
     client.call("risuko.unpauseAll", vec![]).await?;
     println!("All downloads resumed.");
@@ -239,7 +262,8 @@ pub async fn resume_all(args: RpcArgs) -> Result<(), Box<dyn std::error::Error>>
 // Global Stat
 
 pub async fn global_stat(args: RpcArgs) -> Result<(), Box<dyn std::error::Error>> {
-    let client = RpcClient::new(args.rpc_port, args.rpc_secret.clone());
+    let secret = args.rpc_secret.clone().or_else(read_secret_from_config);
+    let client = RpcClient::new(args.rpc_port, secret);
     require_engine(&client).await?;
     let stat = client.call("risuko.getGlobalStat", vec![]).await?;
 
@@ -269,7 +293,8 @@ pub async fn global_stat(args: RpcArgs) -> Result<(), Box<dyn std::error::Error>
 // Files / Peers
 
 pub async fn files(args: GidArgs) -> Result<(), Box<dyn std::error::Error>> {
-    let client = RpcClient::new(args.rpc_port, args.rpc_secret.clone());
+    let secret = args.rpc_secret.clone().or_else(read_secret_from_config);
+    let client = RpcClient::new(args.rpc_port, secret);
     require_engine(&client).await?;
     let result = client
         .call("risuko.getFiles", vec![json!(args.gid)])
@@ -298,7 +323,8 @@ pub async fn files(args: GidArgs) -> Result<(), Box<dyn std::error::Error>> {
 }
 
 pub async fn peers(args: GidArgs) -> Result<(), Box<dyn std::error::Error>> {
-    let client = RpcClient::new(args.rpc_port, args.rpc_secret.clone());
+    let secret = args.rpc_secret.clone().or_else(read_secret_from_config);
+    let client = RpcClient::new(args.rpc_port, secret);
     require_engine(&client).await?;
     let result = client
         .call("risuko.getPeers", vec![json!(args.gid)])
@@ -335,7 +361,8 @@ pub async fn peers(args: GidArgs) -> Result<(), Box<dyn std::error::Error>> {
 // Purge
 
 pub async fn purge(args: RpcArgs) -> Result<(), Box<dyn std::error::Error>> {
-    let client = RpcClient::new(args.rpc_port, args.rpc_secret.clone());
+    let secret = args.rpc_secret.clone().or_else(read_secret_from_config);
+    let client = RpcClient::new(args.rpc_port, secret);
     require_engine(&client).await?;
     client.call("risuko.purgeDownloadResult", vec![]).await?;
     println!("Purged completed/error/removed download results.");
@@ -404,7 +431,8 @@ pub async fn rss(cmd: RssCommand) -> Result<(), Box<dyn std::error::Error>> {
             rpc_port,
             rpc_secret,
         } => {
-            let client = RpcClient::new(rpc_port, rpc_secret);
+            let secret = rpc_secret.or_else(read_secret_from_config);
+            let client = RpcClient::new(rpc_port, secret);
             require_engine(&client).await?;
             let result = client.call("risuko.addRssFeed", vec![json!(url)]).await?;
             println!("{}", serde_json::to_string_pretty(&result)?);
@@ -415,7 +443,8 @@ pub async fn rss(cmd: RssCommand) -> Result<(), Box<dyn std::error::Error>> {
             rpc_secret,
             json,
         } => {
-            let client = RpcClient::new(rpc_port, rpc_secret);
+            let secret = rpc_secret.or_else(read_secret_from_config);
+            let client = RpcClient::new(rpc_port, secret);
             require_engine(&client).await?;
             let result = client.call("risuko.getRssFeeds", vec![]).await?;
             if json {
@@ -438,7 +467,8 @@ pub async fn rss(cmd: RssCommand) -> Result<(), Box<dyn std::error::Error>> {
             rpc_port,
             rpc_secret,
         } => {
-            let client = RpcClient::new(rpc_port, rpc_secret);
+            let secret = rpc_secret.or_else(read_secret_from_config);
+            let client = RpcClient::new(rpc_port, secret);
             require_engine(&client).await?;
             client.call("risuko.refreshAllRssFeeds", vec![]).await?;
             println!("RSS feeds refreshed.");
@@ -449,7 +479,8 @@ pub async fn rss(cmd: RssCommand) -> Result<(), Box<dyn std::error::Error>> {
             rpc_port,
             rpc_secret,
         } => {
-            let client = RpcClient::new(rpc_port, rpc_secret);
+            let secret = rpc_secret.or_else(read_secret_from_config);
+            let client = RpcClient::new(rpc_port, secret);
             require_engine(&client).await?;
             client.call("risuko.removeRssFeed", vec![json!(id)]).await?;
             println!("Removed RSS feed: {}", id);
@@ -474,7 +505,8 @@ pub async fn serve(args: ServeArgs) -> Result<(), Box<dyn std::error::Error>> {
 // Shutdown
 
 pub async fn shutdown(args: RpcArgs) -> Result<(), Box<dyn std::error::Error>> {
-    let client = RpcClient::new(args.rpc_port, args.rpc_secret.clone());
+    let secret = args.rpc_secret.clone().or_else(read_secret_from_config);
+    let client = RpcClient::new(args.rpc_port, secret);
     require_engine(&client).await?;
     client.call("risuko.shutdown", vec![]).await?;
     println!("Shutdown request sent.");

--- a/src-tauri/risuko-cli/src/commands.rs
+++ b/src-tauri/risuko-cli/src/commands.rs
@@ -16,6 +16,12 @@ use crate::{
     RssAction, RssCommand, ServeArgs, StatusArgs,
 };
 
+fn resolve_rpc_secret(explicit: Option<String>) -> Option<String> {
+    explicit
+        .filter(|s| !s.is_empty())
+        .or_else(read_secret_from_config)
+}
+
 /// Read rpc-secret from the config files, returning None if empty or absent
 /// user.json takes precedence over system.json
 fn read_secret_from_config() -> Option<String> {
@@ -38,7 +44,7 @@ fn read_secret_from_config() -> Option<String> {
 // Download
 
 pub async fn download(args: DownloadArgs) -> Result<(), Box<dyn std::error::Error>> {
-    let secret = args.rpc_secret.clone().or_else(read_secret_from_config);
+    let secret = resolve_rpc_secret(args.rpc_secret.clone());
     let client = RpcClient::new(args.rpc_port, secret.clone());
     let mut headless_engine = None;
 
@@ -156,7 +162,7 @@ async fn do_download(
 // Status
 
 pub async fn status(args: StatusArgs) -> Result<(), Box<dyn std::error::Error>> {
-    let secret = args.rpc_secret.clone().or_else(read_secret_from_config);
+    let secret = resolve_rpc_secret(args.rpc_secret.clone());
     let client = RpcClient::new(args.rpc_port, secret);
     require_engine(&client).await?;
 
@@ -212,7 +218,7 @@ pub async fn status(args: StatusArgs) -> Result<(), Box<dyn std::error::Error>> 
 // Pause / Resume / Remove
 
 pub async fn pause(args: PauseArgs) -> Result<(), Box<dyn std::error::Error>> {
-    let secret = args.rpc_secret.clone().or_else(read_secret_from_config);
+    let secret = resolve_rpc_secret(args.rpc_secret.clone());
     let client = RpcClient::new(args.rpc_port, secret);
     require_engine(&client).await?;
     client.call("risuko.pause", vec![json!(args.gid)]).await?;
@@ -221,7 +227,7 @@ pub async fn pause(args: PauseArgs) -> Result<(), Box<dyn std::error::Error>> {
 }
 
 pub async fn resume(args: ResumeArgs) -> Result<(), Box<dyn std::error::Error>> {
-    let secret = args.rpc_secret.clone().or_else(read_secret_from_config);
+    let secret = resolve_rpc_secret(args.rpc_secret.clone());
     let client = RpcClient::new(args.rpc_port, secret);
     require_engine(&client).await?;
     client.call("risuko.unpause", vec![json!(args.gid)]).await?;
@@ -230,7 +236,7 @@ pub async fn resume(args: ResumeArgs) -> Result<(), Box<dyn std::error::Error>> 
 }
 
 pub async fn remove(args: RemoveArgs) -> Result<(), Box<dyn std::error::Error>> {
-    let secret = args.rpc_secret.clone().or_else(read_secret_from_config);
+    let secret = resolve_rpc_secret(args.rpc_secret.clone());
     let client = RpcClient::new(args.rpc_port, secret);
     require_engine(&client).await?;
     for gid in &args.gids {
@@ -245,7 +251,7 @@ pub async fn remove(args: RemoveArgs) -> Result<(), Box<dyn std::error::Error>> 
 // Pause All / Resume All
 
 pub async fn pause_all(args: RpcArgs) -> Result<(), Box<dyn std::error::Error>> {
-    let secret = args.rpc_secret.clone().or_else(read_secret_from_config);
+    let secret = resolve_rpc_secret(args.rpc_secret.clone());
     let client = RpcClient::new(args.rpc_port, secret);
     require_engine(&client).await?;
     client.call("risuko.pauseAll", vec![]).await?;
@@ -254,7 +260,7 @@ pub async fn pause_all(args: RpcArgs) -> Result<(), Box<dyn std::error::Error>> 
 }
 
 pub async fn resume_all(args: RpcArgs) -> Result<(), Box<dyn std::error::Error>> {
-    let secret = args.rpc_secret.clone().or_else(read_secret_from_config);
+    let secret = resolve_rpc_secret(args.rpc_secret.clone());
     let client = RpcClient::new(args.rpc_port, secret);
     require_engine(&client).await?;
     client.call("risuko.unpauseAll", vec![]).await?;
@@ -265,7 +271,7 @@ pub async fn resume_all(args: RpcArgs) -> Result<(), Box<dyn std::error::Error>>
 // Global Stat
 
 pub async fn global_stat(args: RpcArgs) -> Result<(), Box<dyn std::error::Error>> {
-    let secret = args.rpc_secret.clone().or_else(read_secret_from_config);
+    let secret = resolve_rpc_secret(args.rpc_secret.clone());
     let client = RpcClient::new(args.rpc_port, secret);
     require_engine(&client).await?;
     let stat = client.call("risuko.getGlobalStat", vec![]).await?;
@@ -296,7 +302,7 @@ pub async fn global_stat(args: RpcArgs) -> Result<(), Box<dyn std::error::Error>
 // Files / Peers
 
 pub async fn files(args: GidArgs) -> Result<(), Box<dyn std::error::Error>> {
-    let secret = args.rpc_secret.clone().or_else(read_secret_from_config);
+    let secret = resolve_rpc_secret(args.rpc_secret.clone());
     let client = RpcClient::new(args.rpc_port, secret);
     require_engine(&client).await?;
     let result = client
@@ -326,7 +332,7 @@ pub async fn files(args: GidArgs) -> Result<(), Box<dyn std::error::Error>> {
 }
 
 pub async fn peers(args: GidArgs) -> Result<(), Box<dyn std::error::Error>> {
-    let secret = args.rpc_secret.clone().or_else(read_secret_from_config);
+    let secret = resolve_rpc_secret(args.rpc_secret.clone());
     let client = RpcClient::new(args.rpc_port, secret);
     require_engine(&client).await?;
     let result = client
@@ -364,7 +370,7 @@ pub async fn peers(args: GidArgs) -> Result<(), Box<dyn std::error::Error>> {
 // Purge
 
 pub async fn purge(args: RpcArgs) -> Result<(), Box<dyn std::error::Error>> {
-    let secret = args.rpc_secret.clone().or_else(read_secret_from_config);
+    let secret = resolve_rpc_secret(args.rpc_secret.clone());
     let client = RpcClient::new(args.rpc_port, secret);
     require_engine(&client).await?;
     client.call("risuko.purgeDownloadResult", vec![]).await?;
@@ -434,7 +440,7 @@ pub async fn rss(cmd: RssCommand) -> Result<(), Box<dyn std::error::Error>> {
             rpc_port,
             rpc_secret,
         } => {
-            let secret = rpc_secret.or_else(read_secret_from_config);
+            let secret = resolve_rpc_secret(rpc_secret);
             let client = RpcClient::new(rpc_port, secret);
             require_engine(&client).await?;
             let result = client.call("risuko.addRssFeed", vec![json!(url)]).await?;
@@ -446,7 +452,7 @@ pub async fn rss(cmd: RssCommand) -> Result<(), Box<dyn std::error::Error>> {
             rpc_secret,
             json,
         } => {
-            let secret = rpc_secret.or_else(read_secret_from_config);
+            let secret = resolve_rpc_secret(rpc_secret);
             let client = RpcClient::new(rpc_port, secret);
             require_engine(&client).await?;
             let result = client.call("risuko.getRssFeeds", vec![]).await?;
@@ -470,7 +476,7 @@ pub async fn rss(cmd: RssCommand) -> Result<(), Box<dyn std::error::Error>> {
             rpc_port,
             rpc_secret,
         } => {
-            let secret = rpc_secret.or_else(read_secret_from_config);
+            let secret = resolve_rpc_secret(rpc_secret);
             let client = RpcClient::new(rpc_port, secret);
             require_engine(&client).await?;
             client.call("risuko.refreshAllRssFeeds", vec![]).await?;
@@ -482,7 +488,7 @@ pub async fn rss(cmd: RssCommand) -> Result<(), Box<dyn std::error::Error>> {
             rpc_port,
             rpc_secret,
         } => {
-            let secret = rpc_secret.or_else(read_secret_from_config);
+            let secret = resolve_rpc_secret(rpc_secret);
             let client = RpcClient::new(rpc_port, secret);
             require_engine(&client).await?;
             client.call("risuko.removeRssFeed", vec![json!(id)]).await?;
@@ -508,7 +514,7 @@ pub async fn serve(args: ServeArgs) -> Result<(), Box<dyn std::error::Error>> {
 // Shutdown
 
 pub async fn shutdown(args: RpcArgs) -> Result<(), Box<dyn std::error::Error>> {
-    let secret = args.rpc_secret.clone().or_else(read_secret_from_config);
+    let secret = resolve_rpc_secret(args.rpc_secret.clone());
     let client = RpcClient::new(args.rpc_port, secret);
     require_engine(&client).await?;
     client.call("risuko.shutdown", vec![]).await?;

--- a/src-tauri/risuko-cli/src/commands.rs
+++ b/src-tauri/risuko-cli/src/commands.rs
@@ -16,11 +16,14 @@ use crate::{
     RssAction, RssCommand, ServeArgs, StatusArgs,
 };
 
-/// Read rpc-secret from the config files, returning None if empty or absent.
+/// Read rpc-secret from the config files, returning None if empty or absent
+/// user.json takes precedence over system.json
 fn read_secret_from_config() -> Option<String> {
     let config_dir = get_config_dir();
-    let system = load_config(&config_dir.join("system.json"), Map::new());
-    let secret = system
+    let mut merged = load_config(&config_dir.join("system.json"), Map::new());
+    let user = load_config(&config_dir.join("user.json"), Map::new());
+    merged.extend(user);
+    let secret = merged
         .get("rpc-secret")
         .and_then(|v| v.as_str())
         .unwrap_or("")

--- a/src-tauri/src/cli/commands.rs
+++ b/src-tauri/src/cli/commands.rs
@@ -6,20 +6,48 @@ use super::rpc_client::RpcClient;
 use super::{DownloadArgs, PauseArgs, RemoveArgs, ResumeArgs, ServeArgs, StatusArgs};
 use risuko_engine::engine::youtube::is_youtube_uri;
 
+/// Read rpc-secret from the config files, returning None if empty or absent.
+fn read_secret_from_config() -> Option<String> {
+    let config_dir = dirs::config_dir().map(|d| d.join("dev.risuko.app"))?;
+    let system = load_config_file(&config_dir.join("system.json"));
+    let secret = system
+        .get("rpc-secret")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    if secret.is_empty() {
+        None
+    } else {
+        Some(secret)
+    }
+}
+
+fn load_config_file(path: &std::path::Path) -> serde_json::Map<String, Value> {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|data| serde_json::from_str::<Value>(&data).ok())
+        .and_then(|v| {
+            if let Value::Object(m) = v {
+                Some(m)
+            } else {
+                None
+            }
+        })
+        .unwrap_or_default()
+}
+
 pub async fn download(args: DownloadArgs) -> Result<(), Box<dyn std::error::Error>> {
-    let mut secret = args.rpc_secret.clone();
+    let mut secret = args.rpc_secret.clone().or_else(read_secret_from_config);
     let client = RpcClient::new(args.rpc_port, secret.clone());
     let mut headless_engine = None;
 
     if !client.is_engine_running().await {
         eprintln!("No running Risuko instance found. Starting headless engine...");
         let engine = headless::start_headless_engine(args.rpc_port).await?;
-        // Use the engine's configured secret if no CLI secret was provided
         if secret.is_none() {
             secret = engine.rpc_secret().map(|s| s.to_string());
         }
         headless_engine = Some(engine);
-        // Wait briefly for engine to be ready
         tokio::time::sleep(std::time::Duration::from_millis(200)).await;
     }
 
@@ -132,7 +160,8 @@ async fn do_download(
 }
 
 pub async fn status(args: StatusArgs) -> Result<(), Box<dyn std::error::Error>> {
-    let client = RpcClient::new(args.rpc_port, args.rpc_secret);
+    let secret = args.rpc_secret.or_else(read_secret_from_config);
+    let client = RpcClient::new(args.rpc_port, secret);
     require_engine(&client).await?;
 
     if let Some(ref gid) = args.gid {
@@ -197,7 +226,8 @@ pub async fn status(args: StatusArgs) -> Result<(), Box<dyn std::error::Error>> 
 }
 
 pub async fn pause(args: PauseArgs) -> Result<(), Box<dyn std::error::Error>> {
-    let client = RpcClient::new(args.rpc_port, args.rpc_secret);
+    let secret = args.rpc_secret.or_else(read_secret_from_config);
+    let client = RpcClient::new(args.rpc_port, secret);
     require_engine(&client).await?;
 
     client.call("risuko.pause", vec![json!(args.gid)]).await?;
@@ -206,7 +236,8 @@ pub async fn pause(args: PauseArgs) -> Result<(), Box<dyn std::error::Error>> {
 }
 
 pub async fn resume(args: ResumeArgs) -> Result<(), Box<dyn std::error::Error>> {
-    let client = RpcClient::new(args.rpc_port, args.rpc_secret);
+    let secret = args.rpc_secret.or_else(read_secret_from_config);
+    let client = RpcClient::new(args.rpc_port, secret);
     require_engine(&client).await?;
 
     client.call("risuko.unpause", vec![json!(args.gid)]).await?;
@@ -215,7 +246,8 @@ pub async fn resume(args: ResumeArgs) -> Result<(), Box<dyn std::error::Error>> 
 }
 
 pub async fn remove(args: RemoveArgs) -> Result<(), Box<dyn std::error::Error>> {
-    let client = RpcClient::new(args.rpc_port, args.rpc_secret);
+    let secret = args.rpc_secret.or_else(read_secret_from_config);
+    let client = RpcClient::new(args.rpc_port, secret);
     require_engine(&client).await?;
 
     client.call("risuko.remove", vec![json!(args.gid)]).await?;

--- a/src-tauri/src/cli/commands.rs
+++ b/src-tauri/src/cli/commands.rs
@@ -6,6 +6,12 @@ use super::rpc_client::RpcClient;
 use super::{DownloadArgs, PauseArgs, RemoveArgs, ResumeArgs, ServeArgs, StatusArgs};
 use risuko_engine::engine::youtube::is_youtube_uri;
 
+fn resolve_rpc_secret(explicit: Option<String>) -> Option<String> {
+    explicit
+        .filter(|s| !s.is_empty())
+        .or_else(read_secret_from_config)
+}
+
 /// Read rpc-secret from the config files, returning None if empty or absent.
 /// user.json takes precedence over system.json
 fn read_secret_from_config() -> Option<String> {
@@ -40,7 +46,7 @@ fn load_config_file(path: &std::path::Path) -> serde_json::Map<String, Value> {
 }
 
 pub async fn download(args: DownloadArgs) -> Result<(), Box<dyn std::error::Error>> {
-    let mut secret = args.rpc_secret.clone().or_else(read_secret_from_config);
+    let mut secret = resolve_rpc_secret(args.rpc_secret.clone());
     let client = RpcClient::new(args.rpc_port, secret.clone());
     let mut headless_engine = None;
 
@@ -163,7 +169,7 @@ async fn do_download(
 }
 
 pub async fn status(args: StatusArgs) -> Result<(), Box<dyn std::error::Error>> {
-    let secret = args.rpc_secret.or_else(read_secret_from_config);
+    let secret = resolve_rpc_secret(args.rpc_secret);
     let client = RpcClient::new(args.rpc_port, secret);
     require_engine(&client).await?;
 
@@ -229,7 +235,7 @@ pub async fn status(args: StatusArgs) -> Result<(), Box<dyn std::error::Error>> 
 }
 
 pub async fn pause(args: PauseArgs) -> Result<(), Box<dyn std::error::Error>> {
-    let secret = args.rpc_secret.or_else(read_secret_from_config);
+    let secret = resolve_rpc_secret(args.rpc_secret);
     let client = RpcClient::new(args.rpc_port, secret);
     require_engine(&client).await?;
 
@@ -239,7 +245,7 @@ pub async fn pause(args: PauseArgs) -> Result<(), Box<dyn std::error::Error>> {
 }
 
 pub async fn resume(args: ResumeArgs) -> Result<(), Box<dyn std::error::Error>> {
-    let secret = args.rpc_secret.or_else(read_secret_from_config);
+    let secret = resolve_rpc_secret(args.rpc_secret);
     let client = RpcClient::new(args.rpc_port, secret);
     require_engine(&client).await?;
 
@@ -249,7 +255,7 @@ pub async fn resume(args: ResumeArgs) -> Result<(), Box<dyn std::error::Error>> 
 }
 
 pub async fn remove(args: RemoveArgs) -> Result<(), Box<dyn std::error::Error>> {
-    let secret = args.rpc_secret.or_else(read_secret_from_config);
+    let secret = resolve_rpc_secret(args.rpc_secret);
     let client = RpcClient::new(args.rpc_port, secret);
     require_engine(&client).await?;
 

--- a/src-tauri/src/cli/commands.rs
+++ b/src-tauri/src/cli/commands.rs
@@ -7,10 +7,13 @@ use super::{DownloadArgs, PauseArgs, RemoveArgs, ResumeArgs, ServeArgs, StatusAr
 use risuko_engine::engine::youtube::is_youtube_uri;
 
 /// Read rpc-secret from the config files, returning None if empty or absent.
+/// user.json takes precedence over system.json
 fn read_secret_from_config() -> Option<String> {
     let config_dir = dirs::config_dir().map(|d| d.join("dev.risuko.app"))?;
-    let system = load_config_file(&config_dir.join("system.json"));
-    let secret = system
+    let mut merged = load_config_file(&config_dir.join("system.json"));
+    let user = load_config_file(&config_dir.join("user.json"));
+    merged.extend(user);
+    let secret = merged
         .get("rpc-secret")
         .and_then(|v| v.as_str())
         .unwrap_or("")


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves peer connection observability and makes the CLI more forgiving with auth. We now log MSE handshake outcomes, encryption status, and disconnect reasons; the CLI falls back to the config `rpc-secret` (prefers `user.json` over `system.json`) when the flag is missing or empty, and local CodeGraph files are ignored.

- **New Features**
  - Added debug logs for MSE handshake success/failure and disconnect reasons.
  - Logged encryption status and current peer count on successful handshake.

- **Bug Fixes**
  - CLI (`src-tauri/risuko-cli` and `src-tauri/src/cli`) reads `rpc-secret` from `user.json` then `system.json` when `--rpc-secret` is missing or empty, ignoring empty values, across all commands.

<sup>Written for commit 4ce6ea854b950c2d51d7e6da79af8cf336966b9d. Summary will update on new commits. <a href="https://cubic.dev/pr/YueMiyuki/Risuko/pull/84?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI commands now fall back to an RPC secret stored in local configuration when not supplied on the command line.

* **Improvements**
  * More detailed logging for peer connections, disconnections, and encryption state to aid diagnostics.

* **Chores**
  * Added ignore rules to exclude local machine artifacts and reduce repository noise.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/YueMiyuki/Risuko/pull/84?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->