### PR TITLE
fix(perf): CPU High usage

### DIFF
--- a/src-tauri/risuko-bt/src/session.rs
+++ b/src-tauri/risuko-bt/src/session.rs
@@ -554,7 +554,7 @@ impl Session {
         // discover peers via trackers, LSD, and inbound connections. For a
         // trackerless torrent—or one with dead trackers, which is common for CN
         // Thunder/Xunlei swarms—this leaves the download with no peer source so it
-        // stalls at 0% even though the swarm is reachable over DHT 
+        // stalls at 0% even though the swarm is reachable over DHT
         if !info.private {
             if let Some(dht) = self.dht.lock().clone() {
                 let info_hash = meta.info_hash;
@@ -575,7 +575,7 @@ impl Session {
                         );
                         while let Some(addr) = rx.recv().await {
                             if cmd_tx.send(TorrentCommand::AddPeer(addr)).await.is_err() {
-                                return // torrent loop ended
+                                return; // torrent loop ended
                             }
                         }
                         // A single lookup rarely returns the whole swarm and DHT peer sets

--- a/src-tauri/risuko-bt/src/torrent.rs
+++ b/src-tauri/risuko-bt/src/torrent.rs
@@ -1030,7 +1030,7 @@ async fn process_peer_event(
             // and recycle their slot to a fresh dial \u2014 see the eviction
             // sweep in the `tick.tick()` arm
             peer.last_recv = Instant::now();
-            {
+            if log::log_enabled!(target: "diag", log::Level::Debug) {
                 let kind = match &msg {
                     Message::KeepAlive => "KeepAlive".to_string(),
                     Message::Choke => "Choke".to_string(),

--- a/src-tauri/risuko-bt/src/utp/stream.rs
+++ b/src-tauri/risuko-bt/src/utp/stream.rs
@@ -478,6 +478,8 @@ impl ConnState {
         }
         self.state = State::Closed;
         self.eof = true;
+        self.unacked.clear();
+        self.send_buf.clear();
         if let Some(tx) = self.connect_notify.take() {
             let _ = tx.send(Err(io::Error::from(kind)));
         }
@@ -841,5 +843,25 @@ mod tests {
         // Wraparound: 1 is after 65535.
         assert!(seq_after(1, 65535));
         assert!(!seq_after(65535, 1));
+    }
+
+    #[test]
+    fn fail_clears_in_flight_so_driver_stops_spinning() {
+        let shared = new_shared("127.0.0.1:1".parse().unwrap(), 2, RoleKind::Initiator);
+        let mut st = shared.state.lock();
+        st.state = State::Connected;
+        st.unacked.push_back(OutPacket {
+            packet_type: PacketType::Data,
+            seq_nr: 2,
+            payload: vec![0u8; MSS],
+            sent_at: Instant::now() - Duration::from_secs(60),
+            transmissions: MAX_RETRANSMITS,
+        });
+        st.send_buf.extend(std::iter::repeat(0u8).take(100));
+
+        st.fail(io::ErrorKind::TimedOut);
+        assert!(st.unacked.is_empty());
+        assert!(st.send_buf.is_empty());
+        assert!(st.next_deadline().is_none());
     }
 }

--- a/src/renderer/styles/responsive.css
+++ b/src/renderer/styles/responsive.css
@@ -101,7 +101,11 @@
 		position: fixed;
 		left: 16px;
 		right: 16px;
-		bottom: calc(env(safe-area-inset-bottom) + var(--android-bottom-bar, 72px) - 14px);
+		bottom: calc(
+			env(safe-area-inset-bottom) +
+			var(--android-bottom-bar, 72px) -
+			14px
+		);
 		z-index: 70;
 		margin: 0;
 		padding: 8px 0 10px;

--- a/src/renderer/utils/native.ts
+++ b/src/renderer/utils/native.ts
@@ -21,7 +21,9 @@ function dirname(path = ""): string {
 		return value;
 	}
 	if (index === 0) {
-		return value.charAt(0) === "/" || value.charAt(0) === "\\" ? value.charAt(0) : value;
+		return value.charAt(0) === "/" || value.charAt(0) === "\\"
+			? value.charAt(0)
+			: value;
 	}
 	// Windows drive root: "C:\file.tmp" → "C:\"; the separator immediately follows the drive letter
 	if (value.charCodeAt(index - 1) === 58 /* ':' */) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes high CPU usage by preventing the uTP driver from spinning after connection failures. Also reduces hot-path logging overhead.

- **Bug Fixes**
  - uTP: On fail(), clear `unacked` and `send_buf`, set EOF/Closed, and remove deadlines so the driver stops spinning; added a unit test to guard this.
  - Torrent: Gate diagnostic logging with `log::log_enabled!(target: "diag", log::Level::Debug)` to avoid unnecessary formatting/work on the hot path.

<sup>Written for commit 12772150d2ab326f6bc7834debd4701c0fb700f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/YueMiyuki/Risuko/pull/86?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed connection state closure to properly clear pending operations and prevent lingering retransmission timers

* **Refactor**
  * Improved code formatting and structure for better maintainability

* **Chores**
  * Optimized logging efficiency
  * Code quality and organization updates

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/YueMiyuki/Risuko/pull/86?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->