### PR TITLE
Fix tasklist max task

### DIFF
--- a/src-tauri/risuko-engine/src/engine/manager.rs
+++ b/src-tauri/risuko-engine/src/engine/manager.rs
@@ -2521,12 +2521,14 @@ impl TaskManager {
             .iter()
             .filter(|t| t.status == TaskStatus::Waiting || t.status == TaskStatus::Paused)
             .collect();
+        let num = num.min(10_000);
         Value::Array(Self::paginate_newest_first(&waiting, offset, num, keys))
     }
 
     pub async fn tell_stopped(&self, offset: i64, num: usize, keys: &[String]) -> Value {
         let tasks = self.tasks.read().await;
         let stopped: Vec<&DownloadTask> = tasks.iter().filter(|t| t.status.is_stopped()).collect();
+        let num = num.min(10_000);
         Value::Array(Self::paginate_newest_first(&stopped, offset, num, keys))
     }
 
@@ -2542,7 +2544,8 @@ impl TaskManager {
             let start = end.saturating_sub(num);
             (start, end)
         } else {
-            let start = len.saturating_sub((-offset) as usize);
+            let back = usize::try_from(offset.unsigned_abs()).unwrap_or(usize::MAX);
+            let start = len.saturating_sub(back);
             let end = start.saturating_add(num).min(len);
             (start, end)
         };

--- a/src-tauri/risuko-engine/src/engine/manager.rs
+++ b/src-tauri/risuko-engine/src/engine/manager.rs
@@ -2521,39 +2521,35 @@ impl TaskManager {
             .iter()
             .filter(|t| t.status == TaskStatus::Waiting || t.status == TaskStatus::Paused)
             .collect();
-
-        let start = if offset >= 0 {
-            offset as usize
-        } else {
-            waiting.len().saturating_sub((-offset) as usize)
-        };
-
-        let slice: Vec<Value> = waiting
-            .iter()
-            .skip(start)
-            .take(num)
-            .map(|t| t.to_rpc_status(keys))
-            .collect();
-        Value::Array(slice)
+        Value::Array(Self::paginate_newest_first(&waiting, offset, num, keys))
     }
 
     pub async fn tell_stopped(&self, offset: i64, num: usize, keys: &[String]) -> Value {
         let tasks = self.tasks.read().await;
         let stopped: Vec<&DownloadTask> = tasks.iter().filter(|t| t.status.is_stopped()).collect();
+        Value::Array(Self::paginate_newest_first(&stopped, offset, num, keys))
+    }
 
-        let start = if offset >= 0 {
-            offset as usize
+    fn paginate_newest_first(
+        items: &[&DownloadTask],
+        offset: i64,
+        num: usize,
+        keys: &[String],
+    ) -> Vec<Value> {
+        let len = items.len();
+        let (start, end) = if offset >= 0 {
+            let end = len.saturating_sub(offset as usize);
+            let start = end.saturating_sub(num);
+            (start, end)
         } else {
-            stopped.len().saturating_sub((-offset) as usize)
+            let start = len.saturating_sub((-offset) as usize);
+            let end = start.saturating_add(num).min(len);
+            (start, end)
         };
-
-        let slice: Vec<Value> = stopped
+        items[start..end]
             .iter()
-            .skip(start)
-            .take(num)
             .map(|t| t.to_rpc_status(keys))
-            .collect();
-        Value::Array(slice)
+            .collect()
     }
 
     pub async fn get_global_stat(&self) -> Value {
@@ -3394,18 +3390,34 @@ mod tests {
             make_task("a1", TaskStatus::Active),
         ]);
 
-        // offset=0, num=2 → first two waiting/paused
+        // offset=0, num=2 → the two NEWEST waiting/paused, in chronological order
         let result = mgr.tell_waiting(0, 2, &[]).await;
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0].get("gid").unwrap(), "w2");
+        assert_eq!(arr[1].get("gid").unwrap(), "w3");
+
+        // offset=1, num=10 → skip the newest, get the rest from the start
+        let result = mgr.tell_waiting(1, 10, &[]).await;
         let arr = result.as_array().unwrap();
         assert_eq!(arr.len(), 2);
         assert_eq!(arr[0].get("gid").unwrap(), "w1");
         assert_eq!(arr[1].get("gid").unwrap(), "w2");
+    }
 
-        // offset=1, num=10 → skip first, get rest
-        let result = mgr.tell_waiting(1, 10, &[]).await;
+    #[tokio::test]
+    async fn tell_waiting_newest_visible_past_cap() {
+        let mut tasks = Vec::new();
+        for i in 0..1005 {
+            tasks.push(make_task(&format!("w{i}"), TaskStatus::Waiting));
+        }
+        let mgr = make_test_manager(tasks);
+
+        let result = mgr.tell_waiting(0, 1000, &[]).await;
         let arr = result.as_array().unwrap();
-        assert_eq!(arr.len(), 2);
-        assert_eq!(arr[0].get("gid").unwrap(), "w2");
+        assert_eq!(arr.len(), 1000);
+        assert_eq!(arr.last().unwrap().get("gid").unwrap(), "w1004");
+        assert_eq!(arr.first().unwrap().get("gid").unwrap(), "w5");
     }
 
     #[tokio::test]

--- a/src-tauri/risuko-engine/src/engine/rpc.rs
+++ b/src-tauri/risuko-engine/src/engine/rpc.rs
@@ -678,14 +678,14 @@ fn dispatch_method<'a>(
 
             "risuko.tellWaiting" => {
                 let offset = params.first().and_then(|v| v.as_i64()).unwrap_or(0);
-                let num = params.get(1).and_then(|v| v.as_u64()).unwrap_or(1000) as usize;
+                let num = params.get(1).and_then(|v| v.as_u64()).unwrap_or(5000) as usize;
                 let keys = get_keys(&params, 2);
                 Ok(state.manager.tell_waiting(offset, num, &keys).await)
             }
 
             "risuko.tellStopped" => {
                 let offset = params.first().and_then(|v| v.as_i64()).unwrap_or(0);
-                let num = params.get(1).and_then(|v| v.as_u64()).unwrap_or(1000) as usize;
+                let num = params.get(1).and_then(|v| v.as_u64()).unwrap_or(5000) as usize;
                 let keys = get_keys(&params, 2);
                 Ok(state.manager.tell_stopped(offset, num, &keys).await)
             }

--- a/src-tauri/src/commands/engine_cmds.rs
+++ b/src-tauri/src/commands/engine_cmds.rs
@@ -999,7 +999,7 @@ pub async fn tell_waiting(
     Ok(manager
         .tell_waiting(
             offset.unwrap_or(0),
-            num.unwrap_or(1000),
+            num.unwrap_or(5000),
             &keys.unwrap_or_default(),
         )
         .await)
@@ -1015,7 +1015,7 @@ pub async fn tell_stopped(
     Ok(manager
         .tell_stopped(
             offset.unwrap_or(0),
-            num.unwrap_or(1000),
+            num.unwrap_or(5000),
             &keys.unwrap_or_default(),
         )
         .await)

--- a/src/renderer/api/Api.ts
+++ b/src/renderer/api/Api.ts
@@ -32,8 +32,8 @@ const ENGINE_RESTART_USER_KEYS: string[] = [
 	"external-engine-secret",
 	"engine-overrides",
 ];
-const DEFAULT_TASK_LIST_FETCH_SIZE = 1000;
-const MAX_TASK_LIST_FETCH_SIZE = 2000;
+const DEFAULT_TASK_LIST_FETCH_SIZE = 5000;
+const MAX_TASK_LIST_FETCH_SIZE = 10000;
 
 const parseConfiguredTaskListFetchSize = () => {
 	const meta = import.meta as unknown as Record<


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes task list pagination so the newest tasks are shown first and raises the fetch cap to avoid hiding recent items.

- **Bug Fixes**
  - `tellWaiting` and `tellStopped` now return the newest tasks within the requested window (chronological order). Shared `paginate_newest_first` helper; tests added for large lists and cap behavior.
  - Increased default/max fetch sizes to 5000/10000 across engine RPC, Tauri commands, and renderer `Api.ts`; engine now clamps requests to 10,000.

<sup>Written for commit 369373691824d97d3b80f30d51047f89a812ae13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/YueMiyuki/Risuko/pull/88?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Task list pagination now shows newest items first, making it easier to view recent tasks.
  * Increased default task fetch size from 1000 to 5000 items for larger result sets.
  * Raised maximum task fetch size to 10000 items to better support large task collections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/YueMiyuki/Risuko/pull/88?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->