### PR TITLE
fix(bt): Close file handles on pause and add multi-file BT UI expansion

### DIFF
--- a/src-tauri/risuko-bt/src/storage.rs
+++ b/src-tauri/risuko-bt/src/storage.rs
@@ -143,12 +143,15 @@ impl FilesystemStorage {
         };
         let mut first_error: Option<io::Error> = None;
         for handle in snapshot {
-            if let Err(e) = task::spawn_blocking(move || handle.sync_data())
+            match task::spawn_blocking(move || handle.sync_data())
                 .await
                 .map_err(|e| io::Error::other(e.to_string()))
             {
-                if first_error.is_none() {
-                    first_error = Some(e);
+                Ok(Ok(())) => {}
+                Ok(Err(e)) | Err(e) => {
+                    if first_error.is_none() {
+                        first_error = Some(e);
+                    }
                 }
             }
         }

--- a/src-tauri/risuko-bt/src/storage.rs
+++ b/src-tauri/risuko-bt/src/storage.rs
@@ -130,6 +130,24 @@ impl FilesystemStorage {
         }
         Ok(arc)
     }
+
+    /// Flush buffered writes and drop every cached file handle,
+    pub async fn close_handles(&self) -> Result<(), StorageError> {
+        let snapshot: Vec<Arc<std::fs::File>> = {
+            let mut guard = self.handles.lock();
+            let snap = guard.iter().filter_map(|h| h.clone()).collect();
+            for slot in guard.iter_mut() {
+                *slot = None;
+            }
+            snap
+        };
+        for handle in snapshot {
+            task::spawn_blocking(move || handle.sync_data())
+                .await
+                .map_err(|e| io::Error::other(e.to_string()))??;
+        }
+        Ok(())
+    }
 }
 
 #[async_trait::async_trait]
@@ -329,6 +347,37 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(b, payload[10..]);
+    }
+
+    #[tokio::test]
+    async fn close_handles_releases_cached_descriptors() {
+        let bytes = build_multi_file_torrent();
+        let meta = parse_torrent(&bytes).unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let root = torrent_root(tmp.path(), &meta.info);
+
+        let storage = FilesystemStorage::new(&meta.info, &root);
+        storage.preallocate().await.unwrap();
+
+        // Writing both files lazily opens and caches a handle per file
+        let payload: Vec<u8> = (0u8..30).collect();
+        storage.write_at(0, &payload).await.unwrap();
+        assert!(
+            storage.handles.lock().iter().any(|h| h.is_some()),
+            "expected at least one cached handle after a write"
+        );
+
+        // Releasing must drop every cached descriptor
+        storage.close_handles().await.unwrap();
+        assert!(
+            storage.handles.lock().iter().all(|h| h.is_none()),
+            "close_handles must clear all cached file handles"
+        );
+
+        // Data persisted and reads transparently reopen handles afterwards
+        let mut out = vec![0u8; 30];
+        storage.read_at(0, &mut out).await.unwrap();
+        assert_eq!(out, payload);
     }
 
     #[tokio::test]

--- a/src-tauri/risuko-bt/src/storage.rs
+++ b/src-tauri/risuko-bt/src/storage.rs
@@ -141,12 +141,22 @@ impl FilesystemStorage {
             }
             snap
         };
+        let mut first_error: Option<io::Error> = None;
         for handle in snapshot {
-            task::spawn_blocking(move || handle.sync_data())
+            if let Err(e) = task::spawn_blocking(move || handle.sync_data())
                 .await
-                .map_err(|e| io::Error::other(e.to_string()))??;
+                .map_err(|e| io::Error::other(e.to_string()))
+            {
+                if first_error.is_none() {
+                    first_error = Some(e);
+                }
+            }
         }
-        Ok(())
+        if let Some(e) = first_error {
+            Err(StorageError::Io(e))
+        } else {
+            Ok(())
+        }
     }
 }
 

--- a/src-tauri/risuko-bt/src/torrent.rs
+++ b/src-tauri/risuko-bt/src/torrent.rs
@@ -579,7 +579,10 @@ async fn torrent_loop(
                     pending_dials.clear();
                     known_addrs.clear();
                     // Wait for in-flight piece write tasks before closing handles
-                    write_tasks.shutdown().await;
+                    let mut handles = Vec::new();
+                    while let Some(handle) = write_tasks.join_next().await {
+                        handles.push(handle);
+                    }
                     // Release the cached file descriptors
                     if let Err(e) = storage.close_handles().await {
                         log::warn!("failed to close storage handles on pause: {e}");

--- a/src-tauri/risuko-bt/src/torrent.rs
+++ b/src-tauri/risuko-bt/src/torrent.rs
@@ -579,9 +579,10 @@ async fn torrent_loop(
                     pending_dials.clear();
                     known_addrs.clear();
                     // Wait for in-flight piece write tasks before closing handles
-                    let mut handles = Vec::new();
-                    while let Some(handle) = write_tasks.join_next().await {
-                        handles.push(handle);
+                    while let Some(result) = write_tasks.join_next().await {
+                        if let Err(e) = result {
+                            log::warn!("write task failed during pause: {e}");
+                        }
                     }
                     // Release the cached file descriptors
                     if let Err(e) = storage.close_handles().await {

--- a/src-tauri/risuko-bt/src/torrent.rs
+++ b/src-tauri/risuko-bt/src/torrent.rs
@@ -597,6 +597,10 @@ async fn torrent_loop(
                     // don't return Stop while a write_at is still pending.
                     // shutdown() aborts then joins all handles
                     write_tasks.shutdown().await;
+                    // Flush and release cached file descriptors
+                    if let Err(e) = storage.close_handles().await {
+                        log::warn!("failed to close storage handles on stop: {e}");
+                    }
                     let _ = ack.send(());
                     break;
                 }

--- a/src-tauri/risuko-bt/src/torrent.rs
+++ b/src-tauri/risuko-bt/src/torrent.rs
@@ -578,6 +578,10 @@ async fn torrent_loop(
                     }
                     pending_dials.clear();
                     known_addrs.clear();
+                    // Release the cached file descriptors
+                    if let Err(e) = storage.close_handles().await {
+                        log::warn!("failed to close storage handles on pause: {e}");
+                    }
                     let _ = ack.send(());
                 }
                 TorrentCommand::Unpause(ack) => {

--- a/src-tauri/risuko-bt/src/torrent.rs
+++ b/src-tauri/risuko-bt/src/torrent.rs
@@ -578,6 +578,8 @@ async fn torrent_loop(
                     }
                     pending_dials.clear();
                     known_addrs.clear();
+                    // Wait for in-flight piece write tasks before closing handles
+                    write_tasks.shutdown().await;
                     // Release the cached file descriptors
                     if let Err(e) = storage.close_handles().await {
                         log::warn!("failed to close storage handles on pause: {e}");

--- a/src-tauri/risuko-engine/src/engine/error_code.rs
+++ b/src-tauri/risuko-engine/src/engine/error_code.rs
@@ -309,7 +309,8 @@ pub fn classify_error(msg: &str, protocol: &str) -> ErrorCode {
             if lower.contains("requested format") || lower.contains("format is not available") {
                 return ErrorCode::MEDIA_FORMAT_UNAVAILABLE;
             }
-            if lower.contains("http error 404") || (lower.contains("404") && lower.contains("http")) {
+            if lower.contains("http error 404") || (lower.contains("404") && lower.contains("http"))
+            {
                 return ErrorCode::HTTP_NOT_FOUND;
             }
         }

--- a/src-tauri/risuko-engine/src/engine/manager.rs
+++ b/src-tauri/risuko-engine/src/engine/manager.rs
@@ -11,6 +11,7 @@ use super::cookie_store::CookieStore;
 use super::error_code::classify_error;
 use super::events::{EngineEvent, EventBroadcaster};
 use super::http;
+use super::media;
 use super::options::EngineOptions;
 use super::routing::{resolve_routing, TaskRoutingRule};
 use super::session::SessionManager;
@@ -21,7 +22,6 @@ use super::task::{
 };
 use super::torrent::{self, TorrentEngine};
 use super::upload::UploadFileSnapshot;
-use super::media;
 use std::collections::HashSet;
 
 const MAGNET_METADATA_ATTEMPT_TIMEOUT_SECS: u64 = 60;

--- a/src-tauri/risuko-engine/src/engine/media.rs
+++ b/src-tauri/risuko-engine/src/engine/media.rs
@@ -107,8 +107,11 @@ pub fn is_force_ytdlp(options: &Map<String, Value>) -> bool {
     options
         .get("force-ytdlp")
         .map(|v| {
-            v.as_bool()
-                .unwrap_or_else(|| v.as_str().map(|s| s.eq_ignore_ascii_case("true")).unwrap_or(false))
+            v.as_bool().unwrap_or_else(|| {
+                v.as_str()
+                    .map(|s| s.eq_ignore_ascii_case("true"))
+                    .unwrap_or(false)
+            })
         })
         .unwrap_or(false)
 }
@@ -544,10 +547,7 @@ fn extract_format(obj: &serde_json::Value) -> Option<MediaFormat> {
     })
 }
 
-pub async fn get_media_info(
-    url: &str,
-    options: &Map<String, Value>,
-) -> Result<MediaInfo, String> {
+pub async fn get_media_info(url: &str, options: &Map<String, Value>) -> Result<MediaInfo, String> {
     check_yt_dlp_available().await?;
 
     let mut cmd = Command::new("yt-dlp");

--- a/src-tauri/risuko-engine/src/engine/mod.rs
+++ b/src-tauri/risuko-engine/src/engine/mod.rs
@@ -9,6 +9,7 @@ pub mod hasher;
 pub mod http;
 pub mod m3u8;
 pub mod manager;
+pub mod media;
 pub mod netrc;
 pub mod options;
 pub mod routing;
@@ -19,7 +20,6 @@ pub mod speed_limiter;
 pub mod ssh_known_hosts;
 pub mod task;
 pub mod torrent;
-pub mod media;
 pub mod upload;
 pub mod uri_selector;
 

--- a/src-tauri/risuko-http/src/client.rs
+++ b/src-tauri/risuko-http/src/client.rs
@@ -74,7 +74,7 @@ impl Client {
     pub fn request<U: IntoUrl>(&self, method: Method, url: U) -> RequestBuilder {
         RequestBuilder::new(self.clone(), method, url.into_url())
     }
-    
+
     pub fn jar_cookies(&self, url: &Url) -> Option<HeaderValue> {
         self.inner.cookie_jar.as_ref()?.cookies(url)
     }

--- a/src-tauri/src/commands/engine_cmds.rs
+++ b/src-tauri/src/commands/engine_cmds.rs
@@ -680,8 +680,8 @@ pub async fn add_uri(
 
         // Route to the yt-dlp media engine for allowlisted sites, or any URL
         // the user explicitly forced via the `force-ytdlp` option
-        let is_media = engine::media::is_media_uri(uri)
-            || engine::media::is_force_ytdlp(&task_options);
+        let is_media =
+            engine::media::is_media_uri(uri) || engine::media::is_force_ytdlp(&task_options);
         // M3u8 uses a temp directory for segments, not a .part file
         let is_m3u8 = engine::m3u8::is_m3u8_uri(uri);
         let legacy_kind = if engine::adc::is_adc_uri(uri) {
@@ -791,9 +791,7 @@ pub async fn get_media_info(
         Some(Value::Object(map)) => map,
         _ => Map::new(),
     };
-    if !engine::media::is_media_uri(&normalized)
-        && !engine::media::is_force_ytdlp(&task_options)
-    {
+    if !engine::media::is_media_uri(&normalized) && !engine::media::is_force_ytdlp(&task_options) {
         return Err("Not a supported media URL".to_string());
     }
 
@@ -838,9 +836,7 @@ pub async fn add_media(
     }
 
     let manager = engine::get_manager().await.ok_or("Engine not running")?;
-    manager
-        .add_media_task(&normalized_url, task_options)
-        .await
+    manager.add_media_task(&normalized_url, task_options).await
 }
 
 const RESOLVE_MAGNET_TIMEOUT_SECS: u64 = 60;

--- a/src/renderer/components/Task/BatchItemCard.vue
+++ b/src/renderer/components/Task/BatchItemCard.vue
@@ -277,15 +277,17 @@ export default {
 			this.$emit("update:media", this.item.id, {
 				forceYtdlp: value,
 				// Clear all stale media metadata when toggling off
-				...(value ? {} : {
-					mediaFormatId: "",
-					mediaFormats: [],
-					mediaFormatLabel: "",
-					mediaInfoState: "idle",
-					mediaInfoError: "",
-					mediaTitle: "",
-					mediaThumbnail: "",
-				}),
+				...(value
+					? {}
+					: {
+							mediaFormatId: "",
+							mediaFormats: [],
+							mediaFormatLabel: "",
+							mediaInfoState: "idle",
+							mediaInfoError: "",
+							mediaTitle: "",
+							mediaThumbnail: "",
+						}),
 			});
 		},
 		onSelectFormat(value: string) {

--- a/src/renderer/components/Task/TaskItem.vue
+++ b/src/renderer/components/Task/TaskItem.vue
@@ -28,13 +28,52 @@
         />
         <mo-task-progress-info :task="task" />
       </div>
+      <div v-if="isMultiFileBT" class="task-files">
+        <button
+          type="button"
+          class="task-files-toggle"
+          @click.stop="toggleFiles"
+        >
+          <ChevronDown v-if="filesExpanded" :size="12" />
+          <ChevronRight v-else :size="12" />
+          <span>{{ $t('task.bt-files-count', { count: displayFiles.length }) }}</span>
+        </button>
+        <div v-show="filesExpanded" class="task-files-list">
+          <div
+            v-for="file in displayFiles"
+            :key="file.index"
+            class="task-file-row"
+            :class="{ 'is-complete': file.isComplete }"
+          >
+            <div class="task-file-head">
+              <span class="task-file-name" :title="file.path">{{ file.name }}</span>
+              <span class="task-file-pct">{{ file.percent }}%</span>
+            </div>
+            <mo-task-progress
+              :completed="file.completed"
+              :total="file.total"
+              :status="file.status"
+            />
+            <div class="task-file-meta">
+              <span>{{ formatBytes(file.completed) }} / {{ formatBytes(file.total) }}</span>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </template>
 
 <script lang="ts">
+import { ChevronDown, ChevronRight } from "@lucide/vue";
 import { TASK_STATUS } from "@shared/constants";
-import { checkTaskIsSeeder, getTaskName } from "@shared/utils";
+import {
+	bytesToSize,
+	calcProgress,
+	checkTaskIsBT,
+	checkTaskIsSeeder,
+	getTaskName,
+} from "@shared/utils";
 import logger from "@shared/utils/logger";
 import { useTaskStore } from "@/store/task";
 import { getTaskFullPath, openItem } from "@/utils/native";
@@ -48,6 +87,8 @@ export default {
 		[TaskItemActions.name]: TaskItemActions,
 		[TaskProgress.name]: TaskProgress,
 		[TaskProgressInfo.name]: TaskProgressInfo,
+		ChevronDown,
+		ChevronRight,
 	},
 	props: {
 		task: {
@@ -57,6 +98,11 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+	},
+	data() {
+		return {
+			filesExpanded: true,
+		};
 	},
 	computed: {
 		taskFullName() {
@@ -72,6 +118,38 @@ export default {
 		},
 		isSeeder() {
 			return checkTaskIsSeeder(this.task);
+		},
+		isMultiFileBT() {
+			const files = Array.isArray(this.task.files) ? this.task.files : [];
+			return checkTaskIsBT(this.task) && files.length > 1;
+		},
+		// Selected files of a multi-file BT torrent, each with its own
+		// progress so the grouped card can show per-file status
+		displayFiles() {
+			const files = Array.isArray(this.task.files) ? this.task.files : [];
+			return files
+				.filter((f) => f.selected !== "false")
+				.map((f) => {
+					const total = Number(f.length || 0);
+					const completed = Number(f.completedLength || 0);
+					const isComplete = total > 0 && completed >= total;
+					const segs = `${f.path || ""}`.split(/[/\\]/);
+					const name = segs[segs.length - 1] || f.path || "";
+					const percent = `${calcProgress(total, completed, 1)}`.replace(
+						/\.0$/,
+						"",
+					);
+					return {
+						index: f.index,
+						path: f.path,
+						name,
+						total,
+						completed,
+						percent,
+						isComplete,
+						status: isComplete ? TASK_STATUS.COMPLETE : this.taskStatus,
+					};
+				});
 		},
 		taskStatus() {
 			const { task, isSeeder } = this;
@@ -138,6 +216,12 @@ export default {
 		},
 		toggleTask() {
 			useTaskStore().toggleTask(this.task);
+		},
+		toggleFiles() {
+			this.filesExpanded = !this.filesExpanded;
+		},
+		formatBytes(value) {
+			return bytesToSize(value);
 		},
 	},
 };

--- a/src/renderer/components/Task/TaskList.vue
+++ b/src/renderer/components/Task/TaskList.vue
@@ -54,6 +54,7 @@
 </template>
 
 <script lang="ts">
+import { checkTaskIsBT } from "@shared/utils";
 import { cloneDeep } from "lodash";
 import DragSelect from "@/components/DragSelect/Index.vue";
 import is from "@/shims/platform";
@@ -93,7 +94,16 @@ export default {
 			return useTaskStore().totalPages;
 		},
 		useVirtualList() {
-			return this.taskList.length >= VIRTUAL_LIST_THRESHOLD;
+			if (this.taskList.length < VIRTUAL_LIST_THRESHOLD) {
+				return false;
+			}
+			// Grouped multi-file BT cards render a variable-height per-file
+			// list, which breaks the recycler's fixed `item-size`. Fall back
+			// to the flexible renderer whenever a visible card is multi-file.
+			return !this.paginatedTaskList.some((task) => {
+				const files = Array.isArray(task.files) ? task.files : [];
+				return checkTaskIsBT(task) && files.length > 1;
+			});
 		},
 	},
 	mounted() {

--- a/src/renderer/store/task.ts
+++ b/src/renderer/store/task.ts
@@ -592,9 +592,6 @@ export const useTaskStore = defineStore("task", {
 			}
 		},
 		showTaskDetail(task: DisplayTask) {
-			if (task._isFileEntry) {
-				return this.showTaskDetailByGid(task.gid);
-			}
 			this.updateCurrentTaskItem(task);
 			this.currentTaskGid = task.gid;
 			this.taskDetailVisible = true;
@@ -674,30 +671,6 @@ export const useTaskStore = defineStore("task", {
 		},
 		removeTask(task: DownloadTask) {
 			const { gid } = task;
-			const displayTask = task as DisplayTask;
-
-			// For a BT file row, delete means deselect that file
-			// If no files remain selected, fall back to removing the torrent
-			if (displayTask._isFileEntry) {
-				const fileEntry = Array.isArray(task.files) ? task.files[0] : null;
-				const parent = this.taskList.find((t: DownloadTask) => t.gid === gid);
-				if (fileEntry && parent) {
-					const fileIndex = Number(fileEntry.index);
-					const remaining = (Array.isArray(parent.files) ? parent.files : [])
-						.filter((f: DownloadFile) => f.selected !== "false")
-						.map((f: DownloadFile) => Number(f.index))
-						.filter((i: number) => Number.isFinite(i) && i !== fileIndex);
-					if (remaining.length > 0) {
-						const selectFile = remaining.sort((a, b) => a - b).join(",");
-						return api
-							.changeOption({ gid, options: { "select-file": selectFile } })
-							.finally(() => {
-								this.fetchList();
-								this.saveSession();
-							});
-					}
-				}
-			}
 
 			if (gid === this.currentTaskGid) {
 				this.hideTaskDetail();

--- a/src/renderer/store/task.ts
+++ b/src/renderer/store/task.ts
@@ -36,22 +36,9 @@ export function deleteSpeedHistory(gid: string): void {
 }
 
 /** Row count for the task list
- * Multi-file BT torrents expand to one row per selected file, matching `displayTaskList`
- * Everything else is one row */
+ * Each task renders as a single card, including multi-file BT torrents */
 function countDisplayRows(tasks: DownloadTask[]): number {
-	let count = 0;
-	for (const task of tasks) {
-		const files = Array.isArray(task.files) ? task.files : [];
-		if (!checkTaskIsBT(task) || files.length <= 1) {
-			count += 1;
-			continue;
-		}
-		const selected = files.filter(
-			(f: DownloadFile) => f.selected !== "false",
-		).length;
-		count += selected > 0 ? selected : 1;
-	}
-	return count;
+	return tasks.length;
 }
 
 function sampleSpeedsFromTasks(tasks: DownloadTask[]): boolean {
@@ -192,58 +179,11 @@ export const useTaskStore = defineStore("task", {
 			return state.currentPageMap[state.currentList] || 1;
 		},
 		displayTaskList(state) {
-			const result: DisplayTask[] = [];
-			for (const task of state.taskList) {
-				const isBT = checkTaskIsBT(task);
-				const files = Array.isArray(task.files) ? task.files : [];
-				const selectedFiles = files.filter(
-					(f: DownloadFile) => f.selected !== "false",
-				);
-				// Show each selected file in a multi-file BT torrent as its own row
-				// Keep that shape even when only one file remains selected
-				// The title stays as the file name, and row delete deselects instead of removing the torrent
-				if (isBT && files.length > 1 && selectedFiles.length > 0) {
-					const parentDown = Math.max(0, Number(task.downloadSpeed || 0));
-					const parentUp = Math.max(0, Number(task.uploadSpeed || 0));
-					const remainingPerFile = selectedFiles.map((f: DownloadFile) =>
-						Math.max(0, Number(f.length || 0) - Number(f.completedLength || 0)),
-					);
-					const totalRemaining = remainingPerFile.reduce(
-						(sum: number, v: number) => sum + v,
-						0,
-					);
-					selectedFiles.forEach((file: DownloadFile, idx: number) => {
-						const remaining = remainingPerFile[idx];
-						const downShare =
-							totalRemaining > 0
-								? Math.round((parentDown * remaining) / totalRemaining)
-								: 0;
-						// Upload is piece-level, not file-level
-						// Show it once on the first row so the UI does not double-count it
-						const upShare = idx === 0 ? parentUp : 0;
-						result.push({
-							...task,
-							_displayKey: `${task.gid}#f${file.index}`,
-							_isFileEntry: true,
-							totalLength: file.length,
-							completedLength: file.completedLength,
-							downloadSpeed: String(downShare),
-							uploadSpeed: String(upShare),
-							files: [file],
-							bittorrent: {
-								...task.bittorrent,
-								info: {},
-							},
-						});
-					});
-				} else {
-					result.push({
-						...task,
-						_displayKey: task.gid,
-					});
-				}
-			}
-			return result;
+			// One card per task
+			return state.taskList.map((task) => ({
+				...task,
+				_displayKey: task.gid,
+			}));
 		},
 		filteredTaskList(state) {
 			const filter = state.filterText.trim().toLowerCase();

--- a/src/renderer/styles/components/task.css
+++ b/src/renderer/styles/components/task.css
@@ -188,6 +188,75 @@
 	.task-progress {
 		margin-top: auto;
 	}
+	.task-files {
+		margin-top: 10px;
+	}
+	.task-files-toggle {
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
+		padding: 2px 4px;
+		margin-left: -4px;
+		border: 0;
+		background: transparent;
+		color: var(--mo-task-action-color, #6b7280);
+		font-size: 11px;
+		font-weight: 600;
+		line-height: 1;
+		cursor: pointer;
+		border-radius: 4px;
+		transition:
+			color 0.2s ease,
+			background-color 0.2s ease;
+	}
+	.task-files-toggle:hover {
+		color: var(--mo-task-item-text-color);
+		background-color: rgba(127, 127, 127, 0.12);
+	}
+	.task-files-list {
+		margin-top: 6px;
+		max-height: 168px;
+		overflow-y: auto;
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+		padding-right: 2px;
+	}
+	.task-file-row {
+		display: flex;
+		flex-direction: column;
+		gap: 3px;
+	}
+	.task-file-head {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		gap: 8px;
+		font-size: 12px;
+	}
+	.task-file-name {
+		min-width: 0;
+		flex: 1;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		color: var(--mo-task-item-text-color);
+	}
+	.task-file-pct {
+		flex-shrink: 0;
+		font-weight: 600;
+		font-variant-numeric: tabular-nums;
+		color: var(--mo-task-item-text-color);
+	}
+	.task-file-meta {
+		font-size: 11px;
+		font-variant-numeric: tabular-nums;
+		color: var(--mo-task-action-color, #6b7280);
+	}
+	.task-file-row.is-complete .task-file-name,
+	.task-file-row.is-complete .task-file-pct {
+		opacity: 0.7;
+	}
 	.task-actions {
 		position: absolute;
 		top: 20px;

--- a/src/shared/locales/en-US/task.ts
+++ b/src/shared/locales/en-US/task.ts
@@ -43,6 +43,7 @@ export default {
 	"file-completed-size": "Completed",
 	"selected-files-sum":
 		"Selected: {{selectedFilesCount}} files, total size {{selectedFilesTotalSize}}",
+	"bt-files-count": "{{count}} files",
 	"select-at-least-one": "Please select at least one file",
 	"task-gid": "GID",
 	"task-name": "Task Name",

--- a/src/shared/locales/zh-CN/task.ts
+++ b/src/shared/locales/zh-CN/task.ts
@@ -33,6 +33,7 @@ export default {
 	"file-completed-size": "已完成",
 	"selected-files-sum":
 		"已选：{{selectedFilesCount}}个文件，共 {{selectedFilesTotalSize}}",
+	"bt-files-count": "{{count}} 个文件",
 	"select-at-least-one": "请选择至少一个文件",
 	"task-gid": "GID",
 	"task-name": "任务名称",
@@ -219,8 +220,7 @@ export default {
 		'任务"{{taskName}}"：媒体站点下载依赖 yt-dlp。请先安装 yt-dlp，并确保其已加入 PATH。',
 	"media-auth-required":
 		'任务"{{taskName}}"：需要登录验证。请检查是否需要登录或年龄限制访问。',
-	"media-format-unavailable":
-		'任务"{{taskName}}"：该视频不支持所请求的格式。',
+	"media-format-unavailable": '任务"{{taskName}}"：该视频不支持所请求的格式。',
 	"media-force-ytdlp": "使用 yt-dlp 下载",
 	"media-force-ytdlp-tips":
 		"即使该站点不在内置列表中，也通过 yt-dlp 媒体引擎下载此链接。",

--- a/src/shared/locales/zh-TW/task.ts
+++ b/src/shared/locales/zh-TW/task.ts
@@ -33,6 +33,7 @@ export default {
 	"file-completed-size": "已下載",
 	"selected-files-sum":
 		"已選取：{{selectedFilesCount}}個檔案，總計 {{selectedFilesTotalSize}}",
+	"bt-files-count": "{{count}} 個檔案",
 	"select-at-least-one": "請選擇至少一個檔案",
 	"task-gid": "GID",
 	"task-name": "任務名稱",
@@ -219,8 +220,7 @@ export default {
 		'任務"{{taskName}}"：媒體站點下載需要 yt-dlp。請先安裝 yt-dlp，並確認已加入 PATH。',
 	"media-auth-required":
 		'任務"{{taskName}}"：需要登入驗證。請檢查是否需要登入或年齡限制存取。',
-	"media-format-unavailable":
-		'任務"{{taskName}}"：此影片不支援所請求的格式。',
+	"media-format-unavailable": '任務"{{taskName}}"：此影片不支援所請求的格式。',
 	"media-force-ytdlp": "使用 yt-dlp 下載",
 	"media-force-ytdlp-tips":
 		"即使該站點不在內建清單中，也透過 yt-dlp 媒體引擎下載此連結。",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves BT seeding reliability by waiting for in‑flight writes, then flushing and closing cached file descriptors on pause/stop. Adds a collapsible per‑file view inside multi‑file torrent cards with per‑file progress.

- **Bug Fixes**
  - New `close_handles()` in BT storage flushes and drops all cached file descriptors; pause waits for pending writes before closing, and stop shuts down writes then flushes and closes (with unit test) to stabilize seeding.
  - Disable virtual list when any visible task is a multi‑file BT card to avoid recycler height glitches.

- **New Features**
  - One card per task; multi‑file torrents have a toggle to reveal per‑file rows with progress, percent, and size.
  - Added `bt-files-count` translations for en-US, zh-CN, and zh-TW.

<sup>Written for commit de4daa2e0ac2380417b014979b2d75b306be40df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/YueMiyuki/Risuko/pull/93?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expandable per-file details for multi-file torrents with per-file progress and controls.

* **Refactor**
  * Storage now flushes and releases cached file handles to reduce resource usage; invoked on pause/stop flows.
  * Task list/display adjusted to avoid virtualization for variable-height BT cards and to show one display card per task.

* **Localization**
  * Added file-count translations for EN, ZH-CN, and ZH-TW.

* **Tests**
  * Added test verifying handle-closing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->