### PR TITLE
fix(engine): Configurable low-speed threshold and enhanced filename detection

### DIFF
--- a/src-tauri/risuko-engine/src/engine/http.rs
+++ b/src-tauri/risuko-engine/src/engine/http.rs
@@ -2662,8 +2662,8 @@ fn adopt_suggested_filename(
     tracing::debug!(
         "adopt_suggested_filename: new_part={new_part:?}, new_part_has_bytes={new_part_has_bytes}"
     );
-    if new_part_has_bytes && current_part_path.exists() {
-        tracing::debug!("adopt_suggested_filename: rejected (target .part has bytes and current .part still exists)");
+    if new_part_has_bytes {
+        tracing::debug!("adopt_suggested_filename: rejected (target .part has bytes)");
         return None;
     }
     tracing::debug!("adopt_suggested_filename: accepted -> {candidate:?}, {new_part:?}");
@@ -2678,21 +2678,20 @@ fn adopt_content_type_extension(
 ) -> Option<(String, std::path::PathBuf)> {
     let candidate = filename_with_content_type_extension(current_filename, Some(content_type))?;
     let new_part = dir_path.join(format!("{candidate}{PART_SUFFIX}"));
-    if new_part != current_part_path
-        && new_part.exists()
-        && fs::metadata(&new_part)
-            .map(|m| m.len() > 0)
-            .unwrap_or(false)
-        && current_part_path.exists()
-    {
-        return None;
-    }
     if current_part_path.exists()
         && fs::metadata(current_part_path)
             .map(|m| m.len() > 0)
             .unwrap_or(false)
     {
         return Some((candidate, current_part_path.to_path_buf()));
+    }
+    if new_part != current_part_path
+        && new_part.exists()
+        && fs::metadata(&new_part)
+            .map(|m| m.len() > 0)
+            .unwrap_or(false)
+    {
+        return None;
     }
     Some((candidate, new_part))
 }

--- a/src-tauri/risuko-engine/src/engine/http.rs
+++ b/src-tauri/risuko-engine/src/engine/http.rs
@@ -984,6 +984,9 @@ async fn run_single_uri_download(
                     last_modified_header = probe.last_modified.clone();
                 }
                 connections.store(split as u32, Ordering::Relaxed);
+                tracing::debug!(
+                    "run_single_uri_download calling run_multi_chunk: part_path={part_path:?}, filename={filename:?}"
+                );
                 let result = run_multi_chunk(
                     &range_client,
                     uri,
@@ -1713,6 +1716,9 @@ async fn run_multi_chunk(
         return Err(format!("fsync before rename failed: {e}"));
     }
     delete_chunk_meta(part_path);
+    tracing::debug!(
+        "run_multi_chunk finalizing: part_path={part_path:?}, filename={filename:?}"
+    );
     finalize_download(part_path, filename, dir_path)
 }
 
@@ -2404,6 +2410,9 @@ async fn run_single_download(
     }
 
     result?;
+    tracing::debug!(
+        "run_single_download finalizing: part_path={part_path:?}, final_filename={final_filename:?}"
+    );
     let final_path = finalize_download(part_path, &final_filename, dir_path)?;
     Ok((final_path, resp_last_modified))
 }
@@ -2498,6 +2507,9 @@ fn finalize_download(part_path: &Path, filename: &str, dir_path: &Path) -> Resul
         filename.to_string()
     };
     let final_path = dir_path.join(&final_name);
+    tracing::debug!(
+        "finalize_download: part_path={part_path:?}, filename={filename:?}, final_path={final_path:?}"
+    );
     if part_path != final_path {
         fs::rename(part_path, &final_path).map_err(|e| format!("Failed to rename: {e}"))?;
     }
@@ -2614,15 +2626,24 @@ fn adopt_suggested_filename(
     dir_path: &Path,
 ) -> Option<(String, std::path::PathBuf)> {
     let candidate = sanitize_filename(suggested);
+    tracing::debug!(
+        "adopt_suggested_filename: candidate={candidate:?}, current={current_filename:?}, \
+         current_part={current_part_path:?}"
+    );
     if candidate.is_empty() || candidate == current_filename {
+        tracing::debug!("adopt_suggested_filename: rejected (empty or same name)");
         return None;
     }
     // Refuse to rename a download that already has bytes on disk
-    if current_part_path.exists()
+    let current_has_bytes = current_part_path.exists()
         && fs::metadata(current_part_path)
             .map(|m| m.len() > 0)
-            .unwrap_or(false)
-    {
+            .unwrap_or(false);
+    tracing::debug!(
+        "adopt_suggested_filename: current_has_bytes={current_has_bytes}"
+    );
+    if current_has_bytes {
+        tracing::debug!("adopt_suggested_filename: rejected (current .part has bytes)");
         return None;
     }
     let new_part = if candidate.ends_with(PART_SUFFIX) {
@@ -2633,14 +2654,19 @@ fn adopt_suggested_filename(
     // Don't trample another download that's already mid-flight under
     // the suggested filename. A `.part` with bytes belongs to a
     // different task; leaving it alone preserves their work
-    if new_part != current_part_path
+    let new_part_has_bytes = new_part != current_part_path
         && new_part.exists()
         && fs::metadata(&new_part)
             .map(|m| m.len() > 0)
-            .unwrap_or(false)
-    {
+            .unwrap_or(false);
+    tracing::debug!(
+        "adopt_suggested_filename: new_part={new_part:?}, new_part_has_bytes={new_part_has_bytes}"
+    );
+    if new_part_has_bytes && current_part_path.exists() {
+        tracing::debug!("adopt_suggested_filename: rejected (target .part has bytes and current .part still exists)");
         return None;
     }
+    tracing::debug!("adopt_suggested_filename: accepted -> {candidate:?}, {new_part:?}");
     Some((candidate, new_part))
 }
 
@@ -2657,6 +2683,7 @@ fn adopt_content_type_extension(
         && fs::metadata(&new_part)
             .map(|m| m.len() > 0)
             .unwrap_or(false)
+        && current_part_path.exists()
     {
         return None;
     }
@@ -2775,9 +2802,8 @@ fn is_placeholder_download_name(name: &str) -> bool {
 ///
 /// Returns `None` when no usable filename is present
 pub fn filename_from_content_disposition(headers: &HeaderMap) -> Option<String> {
-    let raw = headers
-        .get("content-disposition")
-        .and_then(|v| v.to_str().ok())?;
+    let raw_bytes = headers.get("content-disposition")?.as_bytes();
+    let raw = String::from_utf8_lossy(raw_bytes);
 
     // Prefer filename* (RFC 5987) since it can carry non-ASCII names.
     let mut star_value: Option<String> = None;

--- a/src/renderer/components/Native/EngineClient.vue
+++ b/src/renderer/components/Native/EngineClient.vue
@@ -28,7 +28,6 @@ import {
 const RETRY_STRATEGY_STATIC = "static";
 const RETRY_STRATEGY_EXPONENTIAL = "exponential";
 const AUTO_RETRY_MAX_DELAY_MS = 15 * 60 * 1000;
-const LOW_SPEED_STRIKE_THRESHOLD = 3;
 const LOW_SPEED_RECOVERY_COOLDOWN_MS = 30 * 1000;
 const LOW_SPEED_RESTART_WAIT_MS = 500;
 
@@ -145,6 +144,10 @@ export default {
 			const raw = usePreferenceStore().config.lowSpeedThreshold;
 			const kb = normalizePositiveNumber(raw, 20, 1, 10240);
 			return Math.floor(kb * 1024);
+		},
+		lowSpeedStrikeThreshold() {
+			const raw = usePreferenceStore().config.lowSpeedStrikeThreshold;
+			return normalizePositiveNumber(raw, 5, 1, 20);
 		},
 		preventSleepWhileDownloading() {
 			const raw = usePreferenceStore().config.preventSleepWhileDownloading;
@@ -402,6 +405,8 @@ export default {
 				| "gid"
 				| "status"
 				| "downloadSpeed"
+				| "totalLength"
+				| "completedLength"
 				| "seeder"
 				| "bittorrent"
 				| "ed2kLink"
@@ -416,10 +421,12 @@ export default {
 			// tasks (BT/ED2K/ADC/Gnutella/G2/giFT) take minutes to warm up and a
 			// force-pause aborts that warm-up; the cooldown then refires before
 			// the swarm can rebuild, leaving speed permanently at zero. Filter
-			// down to kinds that actually benefit before consulting the evaluator
-			const eligibleTasks = tasks.filter((task) =>
-				taskBenefitsFromLowSpeedRecovery(task),
-			);
+			// skip tasks whose totalLength is still zero
+			const eligibleTasks = tasks.filter((task) => {
+				if (!taskBenefitsFromLowSpeedRecovery(task)) return false;
+				const total = Number(task?.totalLength || 0);
+				return total > 0;
+			});
 			if (!eligibleTasks.length) {
 				this.lowSpeedStrikeMap = {};
 				this.lowSpeedRecoverAtMap = {};
@@ -439,7 +446,7 @@ export default {
 						};
 					}) as DownloadTask[],
 					thresholdBytes: this.lowSpeedThresholdBytes,
-					strikeThreshold: LOW_SPEED_STRIKE_THRESHOLD,
+					strikeThreshold: this.lowSpeedStrikeThreshold,
 					cooldownMs: LOW_SPEED_RECOVERY_COOLDOWN_MS,
 					nowMs: Date.now(),
 					strikeMap: this.lowSpeedStrikeMap,
@@ -985,6 +992,8 @@ export default {
 					| "gid"
 					| "status"
 					| "downloadSpeed"
+					| "totalLength"
+					| "completedLength"
 					| "seeder"
 					| "bittorrent"
 					| "ed2kLink"
@@ -1003,6 +1012,8 @@ export default {
 									"gid",
 									"status",
 									"downloadSpeed",
+									"totalLength",
+									"completedLength",
 									"seeder",
 									"bittorrent",
 									"ed2kLink",

--- a/src/renderer/components/Native/EngineClient.vue
+++ b/src/renderer/components/Native/EngineClient.vue
@@ -147,7 +147,7 @@ export default {
 		},
 		lowSpeedStrikeThreshold() {
 			const raw = usePreferenceStore().config.lowSpeedStrikeThreshold;
-			return normalizePositiveNumber(raw, 5, 1, 20);
+			return Math.floor(normalizePositiveNumber(raw, 5, 1, 20));
 		},
 		preventSleepWhileDownloading() {
 			const raw = usePreferenceStore().config.preventSleepWhileDownloading;
@@ -406,7 +406,6 @@ export default {
 				| "status"
 				| "downloadSpeed"
 				| "totalLength"
-				| "completedLength"
 				| "seeder"
 				| "bittorrent"
 				| "ed2kLink"
@@ -423,7 +422,9 @@ export default {
 			// the swarm can rebuild, leaving speed permanently at zero. Filter
 			// skip tasks whose totalLength is still zero
 			const eligibleTasks = tasks.filter((task) => {
-				if (!taskBenefitsFromLowSpeedRecovery(task)) return false;
+				if (!taskBenefitsFromLowSpeedRecovery(task)) {
+					return false;
+				}
 				const total = Number(task?.totalLength || 0);
 				return total > 0;
 			});


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip low-speed auto-pause for brand-new downloads until size is known, and harden filename detection/finalization. This prevents premature pauses and misnaming with non-ASCII headers.

- **Bug Fixes**
  - Skip low-speed auto-pause when `totalLength` is 0; include `totalLength`/`completedLength` in polling and subscriptions.
  - Make low-speed strike threshold configurable via preference (default 5).
  - Decode `Content-Disposition` using loss-tolerant parsing to extract non-ASCII filenames.
  - Safer renames: refuse suggested names/extensions if current or target `.part` has bytes; keep current `.part` when adding content-type extensions if it already has bytes.
  - Add detailed debug logs for chunk finalization and filename adoption (paths, decisions) to aid troubleshooting.

<sup>Written for commit ecb4ad11dd34ab918219295481bf55681f365248. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/YueMiyuki/Risuko/pull/99?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Low-speed strike threshold is now user-configurable (range: 1–20)

* **Bug Fixes**
  * Improved download recovery to avoid clobbering in-progress partial files and better validate partial-byte state
  * More tolerant parsing of content-disposition filenames so non-UTF8 header values are handled safely
<!-- end of auto-generated comment: release notes by coderabbit.ai -->