### PR TITLE
fix(engine): prevent superseded workers from clobbering active worker…

### DIFF
--- a/packages/risuko-app/package.json
+++ b/packages/risuko-app/package.json
@@ -1,28 +1,28 @@
 {
-  "name": "@risuko/app",
-  "version": "0.4.2",
-  "description": "Risuko download manager — launches the desktop app, downloading it from GitHub Releases on first run",
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/YueMiyuki/Risuko.git"
-  },
-  "keywords": [
-    "download",
-    "torrent",
-    "bittorrent",
-    "ed2k",
-    "m3u8",
-    "ftp",
-    "download-manager"
-  ],
-  "bin": {
-    "risuko-app": "bin.js"
-  },
-  "files": [
-    "bin.js"
-  ],
-  "engines": {
-    "node": ">=22.0.0"
-  }
+	"name": "@risuko/app",
+	"version": "0.4.2",
+	"description": "Risuko download manager — launches the desktop app, downloading it from GitHub Releases on first run",
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/YueMiyuki/Risuko.git"
+	},
+	"keywords": [
+		"download",
+		"torrent",
+		"bittorrent",
+		"ed2k",
+		"m3u8",
+		"ftp",
+		"download-manager"
+	],
+	"bin": {
+		"risuko-app": "bin.js"
+	},
+	"files": [
+		"bin.js"
+	],
+	"engines": {
+		"node": ">=22.0.0"
+	}
 }

--- a/packages/risuko-cli/npm/darwin-arm64/package.json
+++ b/packages/risuko-cli/npm/darwin-arm64/package.json
@@ -1,23 +1,23 @@
 {
-  "name": "@risuko/cli-darwin-arm64",
-  "version": "0.4.2",
-  "description": "Risuko CLI binary for macOS ARM64",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/YueMiyuki/Risuko.git",
-    "directory": "packages/risuko-cli/npm/darwin-arm64"
-  },
-  "license": "MIT",
-  "os": [
-    "darwin"
-  ],
-  "cpu": [
-    "arm64"
-  ],
-  "scripts": {
-    "prepack": "node ../../../../scripts/ensure-package-artifacts.mjs"
-  },
-  "files": [
-    "risuko"
-  ]
+	"name": "@risuko/cli-darwin-arm64",
+	"version": "0.4.2",
+	"description": "Risuko CLI binary for macOS ARM64",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/YueMiyuki/Risuko.git",
+		"directory": "packages/risuko-cli/npm/darwin-arm64"
+	},
+	"license": "MIT",
+	"os": [
+		"darwin"
+	],
+	"cpu": [
+		"arm64"
+	],
+	"scripts": {
+		"prepack": "node ../../../../scripts/ensure-package-artifacts.mjs"
+	},
+	"files": [
+		"risuko"
+	]
 }

--- a/packages/risuko-cli/npm/darwin-x64/package.json
+++ b/packages/risuko-cli/npm/darwin-x64/package.json
@@ -1,23 +1,23 @@
 {
-  "name": "@risuko/cli-darwin-x64",
-  "version": "0.4.2",
-  "description": "Risuko CLI binary for macOS x64",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/YueMiyuki/Risuko.git",
-    "directory": "packages/risuko-cli/npm/darwin-x64"
-  },
-  "license": "MIT",
-  "os": [
-    "darwin"
-  ],
-  "cpu": [
-    "x64"
-  ],
-  "scripts": {
-    "prepack": "node ../../../../scripts/ensure-package-artifacts.mjs"
-  },
-  "files": [
-    "risuko"
-  ]
+	"name": "@risuko/cli-darwin-x64",
+	"version": "0.4.2",
+	"description": "Risuko CLI binary for macOS x64",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/YueMiyuki/Risuko.git",
+		"directory": "packages/risuko-cli/npm/darwin-x64"
+	},
+	"license": "MIT",
+	"os": [
+		"darwin"
+	],
+	"cpu": [
+		"x64"
+	],
+	"scripts": {
+		"prepack": "node ../../../../scripts/ensure-package-artifacts.mjs"
+	},
+	"files": [
+		"risuko"
+	]
 }

--- a/packages/risuko-cli/npm/linux-arm64-gnu/package.json
+++ b/packages/risuko-cli/npm/linux-arm64-gnu/package.json
@@ -1,23 +1,23 @@
 {
-  "name": "@risuko/cli-linux-arm64-gnu",
-  "version": "0.4.2",
-  "description": "Risuko CLI binary for Linux ARM64",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/YueMiyuki/Risuko.git",
-    "directory": "packages/risuko-cli/npm/linux-arm64-gnu"
-  },
-  "license": "MIT",
-  "os": [
-    "linux"
-  ],
-  "cpu": [
-    "arm64"
-  ],
-  "scripts": {
-    "prepack": "node ../../../../scripts/ensure-package-artifacts.mjs"
-  },
-  "files": [
-    "risuko"
-  ]
+	"name": "@risuko/cli-linux-arm64-gnu",
+	"version": "0.4.2",
+	"description": "Risuko CLI binary for Linux ARM64",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/YueMiyuki/Risuko.git",
+		"directory": "packages/risuko-cli/npm/linux-arm64-gnu"
+	},
+	"license": "MIT",
+	"os": [
+		"linux"
+	],
+	"cpu": [
+		"arm64"
+	],
+	"scripts": {
+		"prepack": "node ../../../../scripts/ensure-package-artifacts.mjs"
+	},
+	"files": [
+		"risuko"
+	]
 }

--- a/packages/risuko-cli/npm/linux-x64-gnu/package.json
+++ b/packages/risuko-cli/npm/linux-x64-gnu/package.json
@@ -1,23 +1,23 @@
 {
-  "name": "@risuko/cli-linux-x64-gnu",
-  "version": "0.4.2",
-  "description": "Risuko CLI binary for Linux x64",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/YueMiyuki/Risuko.git",
-    "directory": "packages/risuko-cli/npm/linux-x64-gnu"
-  },
-  "license": "MIT",
-  "os": [
-    "linux"
-  ],
-  "cpu": [
-    "x64"
-  ],
-  "scripts": {
-    "prepack": "node ../../../../scripts/ensure-package-artifacts.mjs"
-  },
-  "files": [
-    "risuko"
-  ]
+	"name": "@risuko/cli-linux-x64-gnu",
+	"version": "0.4.2",
+	"description": "Risuko CLI binary for Linux x64",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/YueMiyuki/Risuko.git",
+		"directory": "packages/risuko-cli/npm/linux-x64-gnu"
+	},
+	"license": "MIT",
+	"os": [
+		"linux"
+	],
+	"cpu": [
+		"x64"
+	],
+	"scripts": {
+		"prepack": "node ../../../../scripts/ensure-package-artifacts.mjs"
+	},
+	"files": [
+		"risuko"
+	]
 }

--- a/packages/risuko-cli/npm/win32-arm64-msvc/package.json
+++ b/packages/risuko-cli/npm/win32-arm64-msvc/package.json
@@ -1,23 +1,23 @@
 {
-  "name": "@risuko/cli-win32-arm64-msvc",
-  "version": "0.4.2",
-  "description": "Risuko CLI binary for Windows ARM64",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/YueMiyuki/Risuko.git",
-    "directory": "packages/risuko-cli/npm/win32-arm64-msvc"
-  },
-  "license": "MIT",
-  "os": [
-    "win32"
-  ],
-  "cpu": [
-    "arm64"
-  ],
-  "scripts": {
-    "prepack": "node ../../../../scripts/ensure-package-artifacts.mjs"
-  },
-  "files": [
-    "risuko.exe"
-  ]
+	"name": "@risuko/cli-win32-arm64-msvc",
+	"version": "0.4.2",
+	"description": "Risuko CLI binary for Windows ARM64",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/YueMiyuki/Risuko.git",
+		"directory": "packages/risuko-cli/npm/win32-arm64-msvc"
+	},
+	"license": "MIT",
+	"os": [
+		"win32"
+	],
+	"cpu": [
+		"arm64"
+	],
+	"scripts": {
+		"prepack": "node ../../../../scripts/ensure-package-artifacts.mjs"
+	},
+	"files": [
+		"risuko.exe"
+	]
 }

--- a/packages/risuko-cli/npm/win32-x64-msvc/package.json
+++ b/packages/risuko-cli/npm/win32-x64-msvc/package.json
@@ -1,23 +1,23 @@
 {
-  "name": "@risuko/cli-win32-x64-msvc",
-  "version": "0.4.2",
-  "description": "Risuko CLI binary for Windows x64",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/YueMiyuki/Risuko.git",
-    "directory": "packages/risuko-cli/npm/win32-x64-msvc"
-  },
-  "license": "MIT",
-  "os": [
-    "win32"
-  ],
-  "cpu": [
-    "x64"
-  ],
-  "scripts": {
-    "prepack": "node ../../../../scripts/ensure-package-artifacts.mjs"
-  },
-  "files": [
-    "risuko.exe"
-  ]
+	"name": "@risuko/cli-win32-x64-msvc",
+	"version": "0.4.2",
+	"description": "Risuko CLI binary for Windows x64",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/YueMiyuki/Risuko.git",
+		"directory": "packages/risuko-cli/npm/win32-x64-msvc"
+	},
+	"license": "MIT",
+	"os": [
+		"win32"
+	],
+	"cpu": [
+		"x64"
+	],
+	"scripts": {
+		"prepack": "node ../../../../scripts/ensure-package-artifacts.mjs"
+	},
+	"files": [
+		"risuko.exe"
+	]
 }

--- a/packages/risuko-cli/package.json
+++ b/packages/risuko-cli/package.json
@@ -1,37 +1,37 @@
 {
-  "name": "@risuko/cli",
-  "version": "0.4.2",
-  "description": "Risuko download engine CLI — multi-protocol downloads (HTTP, BitTorrent, ED2K, M3U8, FTP/SFTP)",
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/YueMiyuki/Risuko.git"
-  },
-  "keywords": [
-    "download",
-    "torrent",
-    "bittorrent",
-    "ed2k",
-    "m3u8",
-    "ftp",
-    "cli",
-    "download-manager"
-  ],
-  "bin": {
-    "risuko": "bin.js"
-  },
-  "files": [
-    "bin.js"
-  ],
-  "optionalDependencies": {
-    "@risuko/cli-darwin-arm64": "0.4.2",
-    "@risuko/cli-darwin-x64": "0.4.2",
-    "@risuko/cli-linux-arm64-gnu": "0.4.2",
-    "@risuko/cli-linux-x64-gnu": "0.4.2",
-    "@risuko/cli-win32-arm64-msvc": "0.4.2",
-    "@risuko/cli-win32-x64-msvc": "0.4.2"
-  },
-  "engines": {
-    "node": ">= 18"
-  }
+	"name": "@risuko/cli",
+	"version": "0.4.2",
+	"description": "Risuko download engine CLI — multi-protocol downloads (HTTP, BitTorrent, ED2K, M3U8, FTP/SFTP)",
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/YueMiyuki/Risuko.git"
+	},
+	"keywords": [
+		"download",
+		"torrent",
+		"bittorrent",
+		"ed2k",
+		"m3u8",
+		"ftp",
+		"cli",
+		"download-manager"
+	],
+	"bin": {
+		"risuko": "bin.js"
+	},
+	"files": [
+		"bin.js"
+	],
+	"optionalDependencies": {
+		"@risuko/cli-darwin-arm64": "0.4.2",
+		"@risuko/cli-darwin-x64": "0.4.2",
+		"@risuko/cli-linux-arm64-gnu": "0.4.2",
+		"@risuko/cli-linux-x64-gnu": "0.4.2",
+		"@risuko/cli-win32-arm64-msvc": "0.4.2",
+		"@risuko/cli-win32-x64-msvc": "0.4.2"
+	},
+	"engines": {
+		"node": ">= 18"
+	}
 }

--- a/packages/risuko-js/npm/darwin-arm64/package.json
+++ b/packages/risuko-js/npm/darwin-arm64/package.json
@@ -1,24 +1,24 @@
 {
-  "name": "@risuko/js-darwin-arm64",
-  "version": "0.4.2",
-  "description": "Risuko JS native module for macOS ARM64",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/YueMiyuki/Risuko.git",
-    "directory": "packages/risuko-js/npm/darwin-arm64"
-  },
-  "license": "MIT",
-  "os": [
-    "darwin"
-  ],
-  "cpu": [
-    "arm64"
-  ],
-  "main": "risuko.darwin-arm64.node",
-  "scripts": {
-    "prepack": "node ../../../../scripts/ensure-package-artifacts.mjs"
-  },
-  "files": [
-    "risuko.darwin-arm64.node"
-  ]
+	"name": "@risuko/js-darwin-arm64",
+	"version": "0.4.2",
+	"description": "Risuko JS native module for macOS ARM64",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/YueMiyuki/Risuko.git",
+		"directory": "packages/risuko-js/npm/darwin-arm64"
+	},
+	"license": "MIT",
+	"os": [
+		"darwin"
+	],
+	"cpu": [
+		"arm64"
+	],
+	"main": "risuko.darwin-arm64.node",
+	"scripts": {
+		"prepack": "node ../../../../scripts/ensure-package-artifacts.mjs"
+	},
+	"files": [
+		"risuko.darwin-arm64.node"
+	]
 }

--- a/packages/risuko-js/npm/darwin-x64/package.json
+++ b/packages/risuko-js/npm/darwin-x64/package.json
@@ -1,24 +1,24 @@
 {
-  "name": "@risuko/js-darwin-x64",
-  "version": "0.4.2",
-  "description": "Risuko JS native module for macOS x64",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/YueMiyuki/Risuko.git",
-    "directory": "packages/risuko-js/npm/darwin-x64"
-  },
-  "license": "MIT",
-  "os": [
-    "darwin"
-  ],
-  "cpu": [
-    "x64"
-  ],
-  "main": "risuko.darwin-x64.node",
-  "scripts": {
-    "prepack": "node ../../../../scripts/ensure-package-artifacts.mjs"
-  },
-  "files": [
-    "risuko.darwin-x64.node"
-  ]
+	"name": "@risuko/js-darwin-x64",
+	"version": "0.4.2",
+	"description": "Risuko JS native module for macOS x64",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/YueMiyuki/Risuko.git",
+		"directory": "packages/risuko-js/npm/darwin-x64"
+	},
+	"license": "MIT",
+	"os": [
+		"darwin"
+	],
+	"cpu": [
+		"x64"
+	],
+	"main": "risuko.darwin-x64.node",
+	"scripts": {
+		"prepack": "node ../../../../scripts/ensure-package-artifacts.mjs"
+	},
+	"files": [
+		"risuko.darwin-x64.node"
+	]
 }

--- a/packages/risuko-js/npm/linux-arm64-gnu/package.json
+++ b/packages/risuko-js/npm/linux-arm64-gnu/package.json
@@ -1,27 +1,27 @@
 {
-  "name": "@risuko/js-linux-arm64-gnu",
-  "version": "0.4.2",
-  "description": "Risuko JS native module for Linux ARM64",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/YueMiyuki/Risuko.git",
-    "directory": "packages/risuko-js/npm/linux-arm64-gnu"
-  },
-  "license": "MIT",
-  "os": [
-    "linux"
-  ],
-  "cpu": [
-    "arm64"
-  ],
-  "main": "risuko.linux-arm64-gnu.node",
-  "scripts": {
-    "prepack": "node ../../../../scripts/ensure-package-artifacts.mjs"
-  },
-  "files": [
-    "risuko.linux-arm64-gnu.node"
-  ],
-  "libc": [
-    "glibc"
-  ]
+	"name": "@risuko/js-linux-arm64-gnu",
+	"version": "0.4.2",
+	"description": "Risuko JS native module for Linux ARM64",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/YueMiyuki/Risuko.git",
+		"directory": "packages/risuko-js/npm/linux-arm64-gnu"
+	},
+	"license": "MIT",
+	"os": [
+		"linux"
+	],
+	"cpu": [
+		"arm64"
+	],
+	"main": "risuko.linux-arm64-gnu.node",
+	"scripts": {
+		"prepack": "node ../../../../scripts/ensure-package-artifacts.mjs"
+	},
+	"files": [
+		"risuko.linux-arm64-gnu.node"
+	],
+	"libc": [
+		"glibc"
+	]
 }

--- a/packages/risuko-js/npm/linux-x64-gnu/package.json
+++ b/packages/risuko-js/npm/linux-x64-gnu/package.json
@@ -1,27 +1,27 @@
 {
-  "name": "@risuko/js-linux-x64-gnu",
-  "version": "0.4.2",
-  "description": "Risuko JS native module for Linux x64",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/YueMiyuki/Risuko.git",
-    "directory": "packages/risuko-js/npm/linux-x64-gnu"
-  },
-  "license": "MIT",
-  "os": [
-    "linux"
-  ],
-  "cpu": [
-    "x64"
-  ],
-  "main": "risuko.linux-x64-gnu.node",
-  "scripts": {
-    "prepack": "node ../../../../scripts/ensure-package-artifacts.mjs"
-  },
-  "files": [
-    "risuko.linux-x64-gnu.node"
-  ],
-  "libc": [
-    "glibc"
-  ]
+	"name": "@risuko/js-linux-x64-gnu",
+	"version": "0.4.2",
+	"description": "Risuko JS native module for Linux x64",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/YueMiyuki/Risuko.git",
+		"directory": "packages/risuko-js/npm/linux-x64-gnu"
+	},
+	"license": "MIT",
+	"os": [
+		"linux"
+	],
+	"cpu": [
+		"x64"
+	],
+	"main": "risuko.linux-x64-gnu.node",
+	"scripts": {
+		"prepack": "node ../../../../scripts/ensure-package-artifacts.mjs"
+	},
+	"files": [
+		"risuko.linux-x64-gnu.node"
+	],
+	"libc": [
+		"glibc"
+	]
 }

--- a/packages/risuko-js/npm/win32-arm64-msvc/package.json
+++ b/packages/risuko-js/npm/win32-arm64-msvc/package.json
@@ -1,24 +1,24 @@
 {
-  "name": "@risuko/js-win32-arm64-msvc",
-  "version": "0.4.2",
-  "description": "Risuko JS native module for Windows ARM64",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/YueMiyuki/Risuko.git",
-    "directory": "packages/risuko-js/npm/win32-arm64-msvc"
-  },
-  "license": "MIT",
-  "os": [
-    "win32"
-  ],
-  "cpu": [
-    "arm64"
-  ],
-  "main": "risuko.win32-arm64-msvc.node",
-  "scripts": {
-    "prepack": "node ../../../../scripts/ensure-package-artifacts.mjs"
-  },
-  "files": [
-    "risuko.win32-arm64-msvc.node"
-  ]
+	"name": "@risuko/js-win32-arm64-msvc",
+	"version": "0.4.2",
+	"description": "Risuko JS native module for Windows ARM64",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/YueMiyuki/Risuko.git",
+		"directory": "packages/risuko-js/npm/win32-arm64-msvc"
+	},
+	"license": "MIT",
+	"os": [
+		"win32"
+	],
+	"cpu": [
+		"arm64"
+	],
+	"main": "risuko.win32-arm64-msvc.node",
+	"scripts": {
+		"prepack": "node ../../../../scripts/ensure-package-artifacts.mjs"
+	},
+	"files": [
+		"risuko.win32-arm64-msvc.node"
+	]
 }

--- a/packages/risuko-js/npm/win32-x64-msvc/package.json
+++ b/packages/risuko-js/npm/win32-x64-msvc/package.json
@@ -1,24 +1,24 @@
 {
-  "name": "@risuko/js-win32-x64-msvc",
-  "version": "0.4.2",
-  "description": "Risuko JS native module for Windows x64",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/YueMiyuki/Risuko.git",
-    "directory": "packages/risuko-js/npm/win32-x64-msvc"
-  },
-  "license": "MIT",
-  "os": [
-    "win32"
-  ],
-  "cpu": [
-    "x64"
-  ],
-  "main": "risuko.win32-x64-msvc.node",
-  "scripts": {
-    "prepack": "node ../../../../scripts/ensure-package-artifacts.mjs"
-  },
-  "files": [
-    "risuko.win32-x64-msvc.node"
-  ]
+	"name": "@risuko/js-win32-x64-msvc",
+	"version": "0.4.2",
+	"description": "Risuko JS native module for Windows x64",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/YueMiyuki/Risuko.git",
+		"directory": "packages/risuko-js/npm/win32-x64-msvc"
+	},
+	"license": "MIT",
+	"os": [
+		"win32"
+	],
+	"cpu": [
+		"x64"
+	],
+	"main": "risuko.win32-x64-msvc.node",
+	"scripts": {
+		"prepack": "node ../../../../scripts/ensure-package-artifacts.mjs"
+	},
+	"files": [
+		"risuko.win32-x64-msvc.node"
+	]
 }

--- a/packages/risuko-js/package.json
+++ b/packages/risuko-js/package.json
@@ -1,47 +1,47 @@
 {
-  "name": "@risuko/risuko-js",
-  "version": "0.4.2",
-  "description": "Risuko download engine — Node.js native bindings for multi-protocol downloads (HTTP, BitTorrent, ED2K, M3U8, FTP/SFTP)",
-  "main": "index.js",
-  "types": "index.d.ts",
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/YueMiyuki/Risuko.git"
-  },
-  "keywords": [
-    "download",
-    "torrent",
-    "bittorrent",
-    "ed2k",
-    "m3u8",
-    "ftp",
-    "download-manager"
-  ],
-  "files": [
-    "index.js",
-    "index.d.ts"
-  ],
-  "napi": {
-    "name": "risuko",
-    "triples": {
-      "defaults": true,
-      "additional": [
-        "aarch64-apple-darwin",
-        "aarch64-unknown-linux-gnu",
-        "aarch64-pc-windows-msvc"
-      ]
-    }
-  },
-  "optionalDependencies": {
-    "@risuko/js-darwin-arm64": "0.4.2",
-    "@risuko/js-darwin-x64": "0.4.2",
-    "@risuko/js-linux-x64-gnu": "0.4.2",
-    "@risuko/js-linux-arm64-gnu": "0.4.2",
-    "@risuko/js-win32-x64-msvc": "0.4.2",
-    "@risuko/js-win32-arm64-msvc": "0.4.2"
-  },
-  "engines": {
-    "node": ">= 22"
-  }
+	"name": "@risuko/risuko-js",
+	"version": "0.4.2",
+	"description": "Risuko download engine — Node.js native bindings for multi-protocol downloads (HTTP, BitTorrent, ED2K, M3U8, FTP/SFTP)",
+	"main": "index.js",
+	"types": "index.d.ts",
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/YueMiyuki/Risuko.git"
+	},
+	"keywords": [
+		"download",
+		"torrent",
+		"bittorrent",
+		"ed2k",
+		"m3u8",
+		"ftp",
+		"download-manager"
+	],
+	"files": [
+		"index.js",
+		"index.d.ts"
+	],
+	"napi": {
+		"name": "risuko",
+		"triples": {
+			"defaults": true,
+			"additional": [
+				"aarch64-apple-darwin",
+				"aarch64-unknown-linux-gnu",
+				"aarch64-pc-windows-msvc"
+			]
+		}
+	},
+	"optionalDependencies": {
+		"@risuko/js-darwin-arm64": "0.4.2",
+		"@risuko/js-darwin-x64": "0.4.2",
+		"@risuko/js-linux-x64-gnu": "0.4.2",
+		"@risuko/js-linux-arm64-gnu": "0.4.2",
+		"@risuko/js-win32-x64-msvc": "0.4.2",
+		"@risuko/js-win32-arm64-msvc": "0.4.2"
+	},
+	"engines": {
+		"node": ">= 22"
+	}
 }

--- a/src-tauri/risuko-engine/src/engine/manager.rs
+++ b/src-tauri/risuko-engine/src/engine/manager.rs
@@ -1012,10 +1012,9 @@ impl TaskManager {
                 _ => Err("Unsupported protocol".to_string()),
             };
 
+            let mut tasks_guard = tasks.write().await;
             let is_current =
                 active.read().await.get(&gid_clone).map(|ad| ad.epoch) == Some(worker_epoch);
-
-            let mut tasks_guard = tasks.write().await;
             if let Some(task) = tasks_guard
                 .iter_mut()
                 .find(|t| t.gid == gid_clone)
@@ -1311,10 +1310,9 @@ impl TaskManager {
             .await;
 
             // Update task status
+            let mut tasks_guard = tasks.write().await;
             let is_current =
                 active.read().await.get(&gid_clone).map(|ad| ad.epoch) == Some(worker_epoch);
-
-            let mut tasks_guard = tasks.write().await;
             if let Some(task) = tasks_guard
                 .iter_mut()
                 .find(|t| t.gid == gid_clone)
@@ -1512,10 +1510,9 @@ impl TaskManager {
             };
 
             // Update task status
+            let mut tasks_guard = tasks.write().await;
             let is_current =
                 active.read().await.get(&gid_clone).map(|ad| ad.epoch) == Some(worker_epoch);
-
-            let mut tasks_guard = tasks.write().await;
             if let Some(task) = tasks_guard
                 .iter_mut()
                 .find(|t| t.gid == gid_clone)
@@ -1672,10 +1669,9 @@ impl TaskManager {
             )
             .await;
 
+            let mut tasks_guard = tasks.write().await;
             let is_current =
                 active.read().await.get(&gid_clone).map(|ad| ad.epoch) == Some(worker_epoch);
-
-            let mut tasks_guard = tasks.write().await;
             if let Some(task) = tasks_guard
                 .iter_mut()
                 .find(|t| t.gid == gid_clone)
@@ -1817,10 +1813,9 @@ impl TaskManager {
             )
             .await;
 
+            let mut tasks_guard = tasks.write().await;
             let is_current =
                 active.read().await.get(&gid_clone).map(|ad| ad.epoch) == Some(worker_epoch);
-
-            let mut tasks_guard = tasks.write().await;
             if let Some(task) = tasks_guard
                 .iter_mut()
                 .find(|t| t.gid == gid_clone)
@@ -1955,10 +1950,9 @@ impl TaskManager {
             )
             .await;
 
+            let mut tasks_guard = tasks.write().await;
             let is_current =
                 active.read().await.get(&gid_clone).map(|ad| ad.epoch) == Some(worker_epoch);
-
-            let mut tasks_guard = tasks.write().await;
             if let Some(task) = tasks_guard
                 .iter_mut()
                 .find(|t| t.gid == gid_clone)

--- a/src-tauri/risuko-engine/src/engine/manager.rs
+++ b/src-tauri/risuko-engine/src/engine/manager.rs
@@ -27,7 +27,14 @@ use std::collections::HashSet;
 const MAGNET_METADATA_ATTEMPT_TIMEOUT_SECS: u64 = 60;
 const MAGNET_METADATA_RETRY_DELAY_SECS: u64 = 15;
 
+static WORKER_EPOCH: AtomicU64 = AtomicU64::new(1);
+
+fn next_worker_epoch() -> u64 {
+    WORKER_EPOCH.fetch_add(1, Ordering::Relaxed)
+}
+
 struct ActiveDownload {
+    epoch: u64,
     cancel: Arc<AtomicBool>,
     cancel_token: CancellationToken,
     total: Arc<AtomicU64>,
@@ -925,8 +932,10 @@ impl TaskManager {
             _ => "p2p",
         };
 
+        let worker_epoch = next_worker_epoch();
         let completion_handle = tokio::spawn(async move {
             let ad = ActiveDownload {
+                epoch: worker_epoch,
                 cancel,
                 cancel_token: cancel_token.clone(),
                 total,
@@ -1003,8 +1012,15 @@ impl TaskManager {
                 _ => Err("Unsupported protocol".to_string()),
             };
 
+            let is_current =
+                active.read().await.get(&gid_clone).map(|ad| ad.epoch) == Some(worker_epoch);
+
             let mut tasks_guard = tasks.write().await;
-            if let Some(task) = tasks_guard.iter_mut().find(|t| t.gid == gid_clone) {
+            if let Some(task) = tasks_guard
+                .iter_mut()
+                .find(|t| t.gid == gid_clone)
+                .filter(|_| is_current)
+            {
                 task.total_length = total_ref.load(Ordering::Relaxed);
                 task.completed_length = completed_ref.load(Ordering::Relaxed);
                 task.download_speed = 0;
@@ -1039,12 +1055,12 @@ impl TaskManager {
                     }
                     Err(e) => {
                         if e.contains("cancelled") {
-                            if task.status != TaskStatus::Removed {
+                            if task.status == TaskStatus::Active {
                                 task.status = TaskStatus::Paused;
+                                events.send(EngineEvent::DownloadPause {
+                                    gid: gid_clone.clone(),
+                                });
                             }
-                            events.send(EngineEvent::DownloadPause {
-                                gid: gid_clone.clone(),
-                            });
                         } else {
                             tracing::error!(
                                 "[{}] Download failed for {}: {}",
@@ -1064,7 +1080,10 @@ impl TaskManager {
             }
             drop(tasks_guard);
 
-            active.write().await.remove(&gid_clone);
+            let mut active_guard = active.write().await;
+            if active_guard.get(&gid_clone).map(|ad| ad.epoch) == Some(worker_epoch) {
+                active_guard.remove(&gid_clone);
+            }
         });
 
         drop(completion_handle);
@@ -1258,8 +1277,10 @@ impl TaskManager {
         let adopted_filename: Arc<parking_lot::Mutex<Option<String>>> =
             Arc::new(parking_lot::Mutex::new(None));
         let adopted_filename_dl = adopted_filename.clone();
+        let worker_epoch = next_worker_epoch();
         let completion_handle = tokio::spawn(async move {
             let ad = ActiveDownload {
+                epoch: worker_epoch,
                 cancel,
                 cancel_token: cancel_token.clone(),
                 total,
@@ -1290,8 +1311,15 @@ impl TaskManager {
             .await;
 
             // Update task status
+            let is_current =
+                active.read().await.get(&gid_clone).map(|ad| ad.epoch) == Some(worker_epoch);
+
             let mut tasks_guard = tasks.write().await;
-            if let Some(task) = tasks_guard.iter_mut().find(|t| t.gid == gid_clone) {
+            if let Some(task) = tasks_guard
+                .iter_mut()
+                .find(|t| t.gid == gid_clone)
+                .filter(|_| is_current)
+            {
                 task.total_length = total_ref.load(Ordering::Relaxed);
                 task.completed_length = completed_ref.load(Ordering::Relaxed);
                 task.download_speed = 0;
@@ -1360,13 +1388,12 @@ impl TaskManager {
                     }
                     Err(e) => {
                         if e.contains("cancelled") {
-                            // Don't overwrite Removed status from remove()
-                            if task.status != TaskStatus::Removed {
+                            if task.status == TaskStatus::Active {
                                 task.status = TaskStatus::Paused;
+                                events.send(EngineEvent::DownloadPause {
+                                    gid: gid_clone.clone(),
+                                });
                             }
-                            events.send(EngineEvent::DownloadPause {
-                                gid: gid_clone.clone(),
-                            });
                         } else {
                             tracing::error!("Download failed for {}: {}", gid_clone, e);
                             task.status = TaskStatus::Error;
@@ -1405,8 +1432,10 @@ impl TaskManager {
             }
             drop(tasks_guard);
 
-            // Remove from active downloads
-            active.write().await.remove(&gid_clone);
+            let mut active_guard = active.write().await;
+            if active_guard.get(&gid_clone).map(|ad| ad.epoch) == Some(worker_epoch) {
+                active_guard.remove(&gid_clone);
+            }
         });
 
         // Detach, the completion_handle runs independently
@@ -1442,8 +1471,10 @@ impl TaskManager {
 
         let active_for_insert = active.clone();
         let gid_for_insert = gid.clone();
+        let worker_epoch = next_worker_epoch();
         let completion_handle = tokio::spawn(async move {
             let ad = ActiveDownload {
+                epoch: worker_epoch,
                 cancel,
                 cancel_token: cancel_token.clone(),
                 total,
@@ -1481,8 +1512,15 @@ impl TaskManager {
             };
 
             // Update task status
+            let is_current =
+                active.read().await.get(&gid_clone).map(|ad| ad.epoch) == Some(worker_epoch);
+
             let mut tasks_guard = tasks.write().await;
-            if let Some(task) = tasks_guard.iter_mut().find(|t| t.gid == gid_clone) {
+            if let Some(task) = tasks_guard
+                .iter_mut()
+                .find(|t| t.gid == gid_clone)
+                .filter(|_| is_current)
+            {
                 task.total_length = total_ref.load(Ordering::Relaxed);
                 task.completed_length = completed_ref.load(Ordering::Relaxed);
                 task.download_speed = 0;
@@ -1516,13 +1554,12 @@ impl TaskManager {
                     }
                     Err(e) => {
                         if e.contains("cancelled") {
-                            // Don't overwrite Removed status from remove()
-                            if task.status != TaskStatus::Removed {
+                            if task.status == TaskStatus::Active {
                                 task.status = TaskStatus::Paused;
+                                events.send(EngineEvent::DownloadPause {
+                                    gid: gid_clone.clone(),
+                                });
                             }
-                            events.send(EngineEvent::DownloadPause {
-                                gid: gid_clone.clone(),
-                            });
                         } else {
                             tracing::error!("[ed2k] Download failed for {}: {}", gid_clone, e);
                             task.status = TaskStatus::Error;
@@ -1537,8 +1574,10 @@ impl TaskManager {
             }
             drop(tasks_guard);
 
-            // Remove from active downloads
-            active.write().await.remove(&gid_clone);
+            let mut active_guard = active.write().await;
+            if active_guard.get(&gid_clone).map(|ad| ad.epoch) == Some(worker_epoch) {
+                active_guard.remove(&gid_clone);
+            }
         });
 
         drop(completion_handle);
@@ -1597,8 +1636,10 @@ impl TaskManager {
 
         let active_for_insert = active.clone();
         let gid_for_insert = gid.clone();
+        let worker_epoch = next_worker_epoch();
         let completion_handle = tokio::spawn(async move {
             let ad = ActiveDownload {
+                epoch: worker_epoch,
                 cancel,
                 cancel_token: cancel_token.clone(),
                 total,
@@ -1631,8 +1672,15 @@ impl TaskManager {
             )
             .await;
 
+            let is_current =
+                active.read().await.get(&gid_clone).map(|ad| ad.epoch) == Some(worker_epoch);
+
             let mut tasks_guard = tasks.write().await;
-            if let Some(task) = tasks_guard.iter_mut().find(|t| t.gid == gid_clone) {
+            if let Some(task) = tasks_guard
+                .iter_mut()
+                .find(|t| t.gid == gid_clone)
+                .filter(|_| is_current)
+            {
                 task.total_length = total_ref.load(Ordering::Relaxed);
                 task.completed_length = completed_ref.load(Ordering::Relaxed);
                 task.download_speed = 0;
@@ -1673,12 +1721,12 @@ impl TaskManager {
                     }
                     Err(e) => {
                         if e.contains("cancelled") {
-                            if task.status != TaskStatus::Removed {
+                            if task.status == TaskStatus::Active {
                                 task.status = TaskStatus::Paused;
+                                events.send(EngineEvent::DownloadPause {
+                                    gid: gid_clone.clone(),
+                                });
                             }
-                            events.send(EngineEvent::DownloadPause {
-                                gid: gid_clone.clone(),
-                            });
                         } else {
                             tracing::error!("[media] Download failed for {}: {}", gid_clone, e);
                             task.status = TaskStatus::Error;
@@ -1693,7 +1741,10 @@ impl TaskManager {
             }
             drop(tasks_guard);
 
-            active.write().await.remove(&gid_clone);
+            let mut active_guard = active.write().await;
+            if active_guard.get(&gid_clone).map(|ad| ad.epoch) == Some(worker_epoch) {
+                active_guard.remove(&gid_clone);
+            }
         });
 
         drop(completion_handle);
@@ -1735,8 +1786,10 @@ impl TaskManager {
 
         let active_for_insert = active.clone();
         let gid_for_insert = gid.clone();
+        let worker_epoch = next_worker_epoch();
         let completion_handle = tokio::spawn(async move {
             let ad = ActiveDownload {
+                epoch: worker_epoch,
                 cancel,
                 cancel_token: cancel_token.clone(),
                 total,
@@ -1764,8 +1817,15 @@ impl TaskManager {
             )
             .await;
 
+            let is_current =
+                active.read().await.get(&gid_clone).map(|ad| ad.epoch) == Some(worker_epoch);
+
             let mut tasks_guard = tasks.write().await;
-            if let Some(task) = tasks_guard.iter_mut().find(|t| t.gid == gid_clone) {
+            if let Some(task) = tasks_guard
+                .iter_mut()
+                .find(|t| t.gid == gid_clone)
+                .filter(|_| is_current)
+            {
                 task.total_length = total_ref.load(Ordering::Relaxed);
                 task.completed_length = completed_ref.load(Ordering::Relaxed);
                 task.download_speed = 0;
@@ -1799,13 +1859,12 @@ impl TaskManager {
                     }
                     Err(e) => {
                         if e.contains("cancelled") {
-                            // Don't overwrite Removed status from remove()
-                            if task.status != TaskStatus::Removed {
+                            if task.status == TaskStatus::Active {
                                 task.status = TaskStatus::Paused;
+                                events.send(EngineEvent::DownloadPause {
+                                    gid: gid_clone.clone(),
+                                });
                             }
-                            events.send(EngineEvent::DownloadPause {
-                                gid: gid_clone.clone(),
-                            });
                         } else {
                             tracing::error!("[m3u8] Download failed for {}: {}", gid_clone, e);
                             task.status = TaskStatus::Error;
@@ -1820,7 +1879,10 @@ impl TaskManager {
             }
             drop(tasks_guard);
 
-            active.write().await.remove(&gid_clone);
+            let mut active_guard = active.write().await;
+            if active_guard.get(&gid_clone).map(|ad| ad.epoch) == Some(worker_epoch) {
+                active_guard.remove(&gid_clone);
+            }
         });
 
         drop(completion_handle);
@@ -1862,8 +1924,10 @@ impl TaskManager {
 
         let active_for_insert = active.clone();
         let gid_for_insert = gid.clone();
+        let worker_epoch = next_worker_epoch();
         let completion_handle = tokio::spawn(async move {
             let ad = ActiveDownload {
+                epoch: worker_epoch,
                 cancel,
                 cancel_token: cancel_token.clone(),
                 total,
@@ -1891,8 +1955,15 @@ impl TaskManager {
             )
             .await;
 
+            let is_current =
+                active.read().await.get(&gid_clone).map(|ad| ad.epoch) == Some(worker_epoch);
+
             let mut tasks_guard = tasks.write().await;
-            if let Some(task) = tasks_guard.iter_mut().find(|t| t.gid == gid_clone) {
+            if let Some(task) = tasks_guard
+                .iter_mut()
+                .find(|t| t.gid == gid_clone)
+                .filter(|_| is_current)
+            {
                 task.total_length = total_ref.load(Ordering::Relaxed);
                 task.completed_length = completed_ref.load(Ordering::Relaxed);
                 task.download_speed = 0;
@@ -1926,13 +1997,12 @@ impl TaskManager {
                     }
                     Err(e) => {
                         if e.contains("cancelled") {
-                            // Don't overwrite Removed status from remove()
-                            if task.status != TaskStatus::Removed {
+                            if task.status == TaskStatus::Active {
                                 task.status = TaskStatus::Paused;
+                                events.send(EngineEvent::DownloadPause {
+                                    gid: gid_clone.clone(),
+                                });
                             }
-                            events.send(EngineEvent::DownloadPause {
-                                gid: gid_clone.clone(),
-                            });
                         } else {
                             tracing::error!("[ftp] Download failed for {}: {}", gid_clone, e);
                             task.status = TaskStatus::Error;
@@ -1947,7 +2017,10 @@ impl TaskManager {
             }
             drop(tasks_guard);
 
-            active.write().await.remove(&gid_clone);
+            let mut active_guard = active.write().await;
+            if active_guard.get(&gid_clone).map(|ad| ad.epoch) == Some(worker_epoch) {
+                active_guard.remove(&gid_clone);
+            }
         });
 
         drop(completion_handle);
@@ -3498,6 +3571,7 @@ mod tests {
         mgr.active_downloads.write().await.insert(
             "gid1".to_string(),
             ActiveDownload {
+                epoch: next_worker_epoch(),
                 cancel: cancel.clone(),
                 cancel_token: cancel_token.clone(),
                 total: Arc::new(AtomicU64::new(0)),


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents stale worker tasks from overwriting active download state by introducing per-worker epochs in the engine. Fixes races where superseded workers could update progress, change status, or remove active entries for the same GID.

- **Bug Fixes**
  - Added a global `WORKER_EPOCH` and an `epoch` on `ActiveDownload`; only the current epoch can update task state or remove entries from `active_downloads`.
  - Guarded progress/status updates and event emissions with an epoch check across all protocol workers.
  - On cancellation, set Paused only when the task is Active and emit `DownloadPause` once, avoiding overwriting Removed.

- **Refactors**
  - Normalized `package.json` formatting across `@risuko/app`, `@risuko/cli`, `@risuko/risuko-js`, and platform subpackages (formatting only).

<sup>Written for commit d60f7257cfd0668404d973fad9cf80c14f788b49. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/YueMiyuki/Risuko/pull/110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated formatting and indentation across package configuration files throughout the Risuko application, CLI, and JavaScript packages.

* **Bug Fixes**
  * Enhanced download task lifecycle management to prevent outdated task instances from interfering with active downloads. Improved reliability of concurrent download operations and ensured proper state management during task updates, cancellation, and removal scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->