### PR TITLE
Set up Cursor Cloud dev environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+Risuko is a Tauri v2 desktop download manager: a Vue 3 + Vite renderer plus a Rust
+backend (`src-tauri/`) with an in-process download engine. See `README.md` and
+`docs/CONTRIBUTING.md` for standard usage; the notes below cover only non-obvious,
+cloud-environment caveats.
+
+### Running the desktop app
+- Run dev mode with `DISPLAY=:1 pnpm run dev`. A virtual X display is available at
+  `:1`; the `DISPLAY` env var must be set or the Tauri window cannot open.
+- `pnpm run dev` runs Vite on `127.0.0.1:9080` (via `beforeDevCommand`) and then
+  compiles + launches the Rust shell, which embeds the download engine (JSON-RPC on
+  `127.0.0.1:16800`). No separate database/services are needed for desktop dev.
+- The first `tauri dev` cold-compiles the whole Rust workspace (several minutes on
+  this VM's 4 cores). Subsequent incremental rebuilds are fast (~45s).
+- Benign runtime noise to ignore: `libEGL ... DRI3` warnings (software rendering on
+  the virtual display) and repeated `Gtk-WARNING ... no accelerator ... GtkMenuItem`
+  lines. These do not affect functionality.
+
+### Rust toolchain
+- `src-tauri/Cargo.toml` declares `rust-version = "1.85"`, but the committed
+  `Cargo.lock` pulls transitive deps (e.g. `time`, `zbus`, `serde_with`) that require
+  `rustc >= 1.88`. Use the `stable` toolchain (`rustup default stable`); 1.85 will
+  fail to resolve.
+
+### Tests / lint / typecheck
+- Rust tests: `cd src-tauri && cargo test --workspace` (the full suite passes; there
+  is no `cargo test` step in CI). There is no JS/Vue test runner in this repo.
+- JS/Vue lint+format: `pnpm fmt` (Biome, writes fixes; excludes `src-tauri/`).
+- Typecheck: `pnpm typecheck` (`vue-tsc`).
+- The Husky pre-commit hook runs `pnpm pre-commit` (= `pnpm typecheck` + `pnpm fmt`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for Risuko (Tauri v2 desktop download manager) in the Cursor Cloud VM, and documents non-obvious caveats for future agents.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering how to run the desktop app (`DISPLAY=:1 pnpm run dev`), the Rust toolchain caveat, and lint/test commands.
- Update script configured as `pnpm install` (system deps + Rust toolchain are baked into the VM snapshot).

## Environment setup performed
- Installed Linux Tauri build deps: `libwebkit2gtk-4.1-dev`, `libgtk-3-dev`, `libayatana-appindicator3-dev`, `librsvg2-dev`, `patchelf`, `xdg-utils`, `build-essential`, `libssl-dev`, `libsoup-3.0-dev`.
- Set Rust toolchain to `stable` (1.96). Note: `Cargo.toml` declares `rust-version = 1.85`, but the committed `Cargo.lock` requires `rustc >= 1.88`, so 1.85 fails to resolve.
- `pnpm install` (Node 22, pnpm 11.3.0).

## Verification
- `pnpm typecheck` — passed.
- `pnpx @biomejs/biome check` — passed (one informational schema-version note only).
- `cd src-tauri && cargo test --workspace` — 704 passed, 0 failed.
- `DISPLAY=:1 pnpm run dev` — Tauri app compiled and launched; added a real download (`https://proof.ovh.net/files/10Mb.dat`) which completed to 100% in the task list.

### Demo
[risuko_add_download_demo.mp4](https://cursor.com/agents/bc-2580998e-6d9b-44a3-884c-e11da48b1b02/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frisuko_add_download_demo.mp4)

[Completed download in Risuko](https://cursor.com/agents/bc-2580998e-6d9b-44a3-884c-e11da48b1b02/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frisuko_download_completed.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2580998e-6d9b-44a3-884c-e11da48b1b02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2580998e-6d9b-44a3-884c-e11da48b1b02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds AGENTS.md with Cursor Cloud dev setup notes for the Tauri v2 desktop app, so contributors can run and debug the app in the VM without guesswork. Includes how to launch with `DISPLAY=:1 pnpm run dev`, the Rust toolchain requirement (use `stable`), and commands for tests, lint/format (`pnpm fmt`), and typecheck (`pnpm typecheck`).

<sup>Written for commit e009149de79b6669caad632c381f3ce0a82d2bd5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/YueMiyuki/Risuko/pull/118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

