### PR TITLE
feat(ui): Show direct error button

### DIFF
--- a/scripts/check-i18n.mjs
+++ b/scripts/check-i18n.mjs
@@ -53,6 +53,7 @@ const FEATURE_KEYS = [
 	"task.filter-document",
 	"task.clear-filter",
 	"task.open-source-url",
+	"task.open-error-code-reference",
 	"task.more-actions",
 	"task.batch-remove-item",
 	"task.torrent-preview-folder-toggle",

--- a/src/renderer/components/Health/Index.vue
+++ b/src/renderer/components/Health/Index.vue
@@ -1,32 +1,34 @@
 <template>
   <div class="main panel panel-layout panel-layout--v health-panel">
     <motion-enter tag="header" preset="fadeInDown" class="panel-header health-header">
-      <h4 class="health-title">{{ $t('health.title') }}</h4>
-      <div class="health-actions">
-        <Button
-          size="sm"
-          variant="default"
-          class="health-run-btn"
-          :class="{ 'is-loading': loading }"
-          :disabled="loading"
-          :title="loading ? $t('health.loading') : $t('health.run-all')"
-          :aria-label="loading ? $t('health.loading') : $t('health.run-all')"
-          @click="runAll"
-        >
-          <RefreshCw :size="14" :class="{ 'animate-spin': loading }" />
-          <span>{{ loading ? $t('health.loading') : $t('health.run-all') }}</span>
-        </Button>
-        <Button
-          size="sm"
-          variant="outline"
-          class="health-log-btn"
-          :title="$t('health.inspect-logs')"
-          :aria-label="$t('health.inspect-logs')"
-          @click="logsOpen = true"
-        >
-          <FileText :size="14" />
-          <span>{{ $t('health.inspect-logs') }}</span>
-        </Button>
+      <div class="health-header-main">
+        <h4 class="health-title">{{ $t('health.title') }}</h4>
+        <div class="health-actions">
+          <Button
+            size="sm"
+            variant="default"
+            class="health-run-btn"
+            :class="{ 'is-loading': loading }"
+            :disabled="loading"
+            :title="loading ? $t('health.loading') : $t('health.run-all')"
+            :aria-label="loading ? $t('health.loading') : $t('health.run-all')"
+            @click="runAll"
+          >
+            <RefreshCw :size="14" :class="{ 'animate-spin': loading }" />
+            <span>{{ loading ? $t('health.loading') : $t('health.run-all') }}</span>
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            class="health-log-btn"
+            :title="$t('health.inspect-logs')"
+            :aria-label="$t('health.inspect-logs')"
+            @click="logsOpen = true"
+          >
+            <FileText :size="14" />
+            <span>{{ $t('health.inspect-logs') }}</span>
+          </Button>
+        </div>
       </div>
       <p class="page-desc">{{ $t('health.subtitle') }}</p>
       <div v-if="report" class="page-meta">
@@ -252,6 +254,17 @@ export default {
 	color: var(--muted-foreground);
 	font-variant-numeric: tabular-nums;
 }
+.health-header-main {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	flex: 1 1 100%;
+	min-width: 0;
+	gap: 12px;
+}
+.health-title {
+	min-width: 0;
+}
 .health-actions {
 	display: flex;
 	align-items: center;
@@ -313,8 +326,13 @@ export default {
 	justify-content: center;
 }
 @media (max-width: 640px) {
+	.health-header-main {
+		align-items: flex-start;
+		flex-direction: column;
+		gap: 8px;
+	}
 	.health-actions {
-		flex-basis: 100%;
+		flex-basis: auto;
 		width: 100%;
 		margin-left: 0;
 	}

--- a/src/renderer/components/Native/EngineClient.vue
+++ b/src/renderer/components/Native/EngineClient.vue
@@ -19,7 +19,11 @@ import is from "@/shims/platform";
 import { useAppStore } from "@/store/app";
 import { usePreferenceStore } from "@/store/preference";
 import { useTaskStore } from "@/store/task";
-import { findHttpSourceUrl, openExternalUrl } from "@/utils/external";
+import {
+	findHttpSourceUrl,
+	getErrorCodeReferenceUrl,
+	openExternalUrl,
+} from "@/utils/external";
 import {
 	finalizeCompletedDownloadPath,
 	getTaskFullPath,
@@ -580,6 +584,7 @@ export default {
 				const taskName = getTaskName(task);
 				const { errorCode, errorMessage } = task;
 				const normalizedErrorCode = String(errorCode || "");
+				const errorReferenceUrl = getErrorCodeReferenceUrl(errorCode);
 				const sourceUrl = findHttpSourceUrl(task);
 				logger.error(
 					`[Risuko] download error gid: ${gid}, #${errorCode}, ${errorMessage}`,
@@ -603,10 +608,10 @@ export default {
 					if (host && appStore.cloudflareSkipHosts.includes(host)) {
 						toast.error(this.$t("task.download-error-message", { taskName }), {
 							duration: 5000,
-							action: sourceUrl
+							action: errorReferenceUrl
 								? {
-										label: this.$t("task.open-source-url"),
-										onClick: () => void openExternalUrl(sourceUrl),
+										label: this.$t("task.open-error-code-reference"),
+										onClick: () => void openExternalUrl(errorReferenceUrl),
 									}
 								: undefined,
 						});
@@ -656,13 +661,15 @@ export default {
 				} else {
 					message = this.$t("task.download-error-message", { taskName });
 				}
-				const link = `https://risuko.app/docs/reference/error-codes#${errorCode}`;
-				toast.error(`${message} (${errorCode}) ${link}`, {
+				const errorCodeSuffix = normalizedErrorCode
+					? ` (${normalizedErrorCode})`
+					: "";
+				toast.error(`${message}${errorCodeSuffix}`, {
 					duration: isMissingYtDlp || usenetRepairFailure ? 9000 : 5000,
-					action: sourceUrl
+					action: errorReferenceUrl
 						? {
-								label: this.$t("task.open-source-url"),
-								onClick: () => void openExternalUrl(sourceUrl),
+								label: this.$t("task.open-error-code-reference"),
+								onClick: () => void openExternalUrl(errorReferenceUrl),
 							}
 						: undefined,
 				});

--- a/src/renderer/components/Task/BatchItemCard.vue
+++ b/src/renderer/components/Task/BatchItemCard.vue
@@ -181,18 +181,6 @@
         </div>
         <div v-if="item.error" class="mt-2 flex flex-wrap items-center gap-2 text-xs text-destructive">
           <span>{{ item.error }}</span>
-          <Button
-            v-if="sourceUrl"
-            variant="outline"
-            size="sm"
-            class="h-7 px-2 text-[11px]"
-            :title="$t('task.open-source-url')"
-            :aria-label="$t('task.open-source-url')"
-            @click.stop="openSourceUrl"
-          >
-            <ExternalLink :size="12" />
-            {{ $t('task.open-source-url') }}
-          </Button>
         </div>
       </AccordionContent>
     </AccordionItem>
@@ -200,14 +188,7 @@
 </template>
 
 <script lang="ts">
-import {
-	ExternalLink,
-	FileArchive,
-	Link2,
-	Magnet,
-	Video,
-	X,
-} from "@lucide/vue";
+import { FileArchive, Link2, Magnet, Video, X } from "@lucide/vue";
 import type { MediaFormat } from "@shared/types/task";
 import { bytesToSize } from "@shared/utils";
 import api from "@/api";
@@ -229,7 +210,6 @@ import {
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import type { BatchQueueItem } from "@/store/batchQueue";
-import { isHttpUrl, openExternalUrl } from "@/utils/external";
 
 export default {
 	name: "batch-item-card",
@@ -249,7 +229,6 @@ export default {
 		Switch,
 		Video,
 		X,
-		ExternalLink,
 	},
 	props: {
 		item: {
@@ -324,10 +303,6 @@ export default {
 			}
 			return /^https?:\/\//i.test(this.item.uri.trim());
 		},
-		sourceUrl(): string {
-			const value = this.item.uri?.trim() || "";
-			return isHttpUrl(value) ? value : "";
-		},
 		// Formats can be fetched once the item is treated as media
 		canFetchFormats(): boolean {
 			return !!(this.item.isMedia || this.item.forceYtdlp);
@@ -387,9 +362,6 @@ export default {
 		removeMirror(idx: number) {
 			const next = this.mirrors.filter((_, i) => i !== idx);
 			this.$emit("update:mirrors", this.item.id, next);
-		},
-		openSourceUrl() {
-			void openExternalUrl(this.sourceUrl);
 		},
 		onToggleForce(value: boolean) {
 			this.$emit("update:media", this.item.id, {

--- a/src/renderer/components/Task/CloudflareDialog.vue
+++ b/src/renderer/components/Task/CloudflareDialog.vue
@@ -185,6 +185,18 @@
         </UiButton>
         <UiButton
           type="button"
+          variant="ghost"
+          size="sm"
+          :title="$t('task.open-error-code-reference')"
+          :aria-label="$t('task.open-error-code-reference')"
+          :disabled="retrying || importing"
+          @click="handleOpenErrorReference"
+        >
+          <ExternalLink :size="12" class="mr-1" />
+          {{ $t('task.open-error-code-reference') }}
+        </UiButton>
+        <UiButton
+          type="button"
           size="sm"
           :disabled="!selectedBrowser || retrying || importing"
           @click="imported ? handleApplyAndRetry() : handlePreview()"
@@ -227,7 +239,7 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import { useAppStore } from "@/store/app";
 import { usePreferenceStore } from "@/store/preference";
-import { openExternalUrl } from "@/utils/external";
+import { getErrorCodeReferenceUrl, openExternalUrl } from "@/utils/external";
 
 let cachedBrowsers: BrowserInfo[] | null = null;
 
@@ -301,6 +313,9 @@ export default {
 		},
 		url(): string {
 			return this.dialogState.url;
+		},
+		errorCodeReferenceUrl(): string {
+			return getErrorCodeReferenceUrl("315");
 		},
 		retried(): boolean {
 			return this.dialogState.retried;
@@ -384,6 +399,11 @@ export default {
 				}
 			} catch (e) {
 				toast.error(String(e));
+			}
+		},
+		async handleOpenErrorReference() {
+			if (!(await openExternalUrl(this.errorCodeReferenceUrl))) {
+				toast.error(this.$t("app.open-url-failed"));
 			}
 		},
 		async handleCaptureUa() {

--- a/src/renderer/components/Task/CloudflareDialog.vue
+++ b/src/renderer/components/Task/CloudflareDialog.vue
@@ -185,18 +185,6 @@
         </UiButton>
         <UiButton
           type="button"
-          variant="ghost"
-          size="sm"
-          :title="$t('task.open-error-code-reference')"
-          :aria-label="$t('task.open-error-code-reference')"
-          :disabled="retrying || importing"
-          @click="handleOpenErrorReference"
-        >
-          <ExternalLink :size="12" class="mr-1" />
-          {{ $t('task.open-error-code-reference') }}
-        </UiButton>
-        <UiButton
-          type="button"
           size="sm"
           :disabled="!selectedBrowser || retrying || importing"
           @click="imported ? handleApplyAndRetry() : handlePreview()"
@@ -239,7 +227,7 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import { useAppStore } from "@/store/app";
 import { usePreferenceStore } from "@/store/preference";
-import { getErrorCodeReferenceUrl, openExternalUrl } from "@/utils/external";
+import { openExternalUrl } from "@/utils/external";
 
 let cachedBrowsers: BrowserInfo[] | null = null;
 
@@ -313,9 +301,6 @@ export default {
 		},
 		url(): string {
 			return this.dialogState.url;
-		},
-		errorCodeReferenceUrl(): string {
-			return getErrorCodeReferenceUrl("315");
 		},
 		retried(): boolean {
 			return this.dialogState.retried;
@@ -399,11 +384,6 @@ export default {
 				}
 			} catch (e) {
 				toast.error(String(e));
-			}
-		},
-		async handleOpenErrorReference() {
-			if (!(await openExternalUrl(this.errorCodeReferenceUrl))) {
-				toast.error(this.$t("app.open-url-failed"));
 			}
 		},
 		async handleCaptureUa() {

--- a/src/renderer/components/TaskDetail/TaskGeneral.vue
+++ b/src/renderer/components/TaskDetail/TaskGeneral.vue
@@ -62,16 +62,16 @@
         <span class="general-card-value general-card-value--error flex flex-wrap items-center gap-2">
           <span class="min-w-0">{{ task.errorCode }} {{ taskErrorMessage }}</span>
           <Button
-            v-if="sourceUrl"
+            v-if="errorCodeReferenceUrl"
             variant="outline"
             size="sm"
             class="ml-2 shrink-0"
-            :title="$t('task.open-source-url')"
-            :aria-label="$t('task.open-source-url')"
-            @click="openSourceUrl"
+            :title="$t('task.open-error-code-reference')"
+            :aria-label="$t('task.open-error-code-reference')"
+            @click="openErrorCodeReference"
           >
             <ExternalLink :size="13" />
-            {{ $t('task.open-source-url') }}
+            {{ $t('task.open-error-code-reference') }}
           </Button>
         </span>
       </div>
@@ -150,7 +150,7 @@ import is from "@/shims/platform";
 import { useAppStore } from "@/store/app";
 import { usePreferenceStore } from "@/store/preference";
 import { copyText } from "@/utils/clipboard";
-import { findHttpSourceUrl, openExternalUrl } from "@/utils/external";
+import { getErrorCodeReferenceUrl, openExternalUrl } from "@/utils/external";
 import { getTaskRevealDir, getTaskRevealPath } from "@/utils/native";
 
 export default {
@@ -218,8 +218,8 @@ export default {
 		taskErrorMessage() {
 			return this.usenetRepairFailureMessage || this.task?.errorMessage || "";
 		},
-		sourceUrl(): string {
-			return findHttpSourceUrl(this.task);
+		errorCodeReferenceUrl(): string {
+			return getErrorCodeReferenceUrl(this.task?.errorCode);
 		},
 		displayDownloadSpeed() {
 			return Number(this.task?.downloadSpeed || 0);
@@ -311,8 +311,10 @@ export default {
 					this.$msg.error(this.$t("task.copy-link-failed"));
 				});
 		},
-		openSourceUrl() {
-			void openExternalUrl(this.sourceUrl);
+		async openErrorCodeReference() {
+			if (!(await openExternalUrl(this.errorCodeReferenceUrl))) {
+				this.$msg.error(this.$t("app.open-url-failed"));
+			}
 		},
 	},
 	beforeUnmount() {

--- a/src/renderer/styles/android.css
+++ b/src/renderer/styles/android.css
@@ -912,15 +912,22 @@ html.platform-android .health-header {
 	padding: 0 16px 8px;
 	border-bottom: 0;
 }
-html.platform-android .health-header > .health-title {
-	flex: 1 1 0;
+html.platform-android .health-header > .health-header-main {
+	display: flex;
+	align-items: flex-start;
+	flex-direction: column;
+	flex: 1 1 100%;
 	min-width: 0;
+	gap: 8px;
+}
+html.platform-android .health-header .health-title {
+	flex: 1 1 0;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
 }
-html.platform-android .health-header > .health-actions {
-	flex: 1 0 100%;
+html.platform-android .health-header .health-actions {
+	flex: 0 0 auto;
 	width: 100%;
 	justify-content: flex-end;
 	margin-left: 0;

--- a/src/renderer/utils/external.test.ts
+++ b/src/renderer/utils/external.test.ts
@@ -45,6 +45,7 @@ test("builds error-code reference URLs only for canonical numeric codes", () => 
 		"https://risuko.app/docs/reference/error-codes#540",
 	);
 	assert.equal(getErrorCodeReferenceUrl("0"), "");
+	assert.equal(getErrorCodeReferenceUrl("000"), "");
 	assert.equal(getErrorCodeReferenceUrl("315#other"), "");
 	assert.equal(getErrorCodeReferenceUrl("not-a-code"), "");
 });

--- a/src/renderer/utils/external.test.ts
+++ b/src/renderer/utils/external.test.ts
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { findHttpSourceUrl, isHttpUrl, openExternalUrl } from "./external.ts";
+import {
+	findHttpSourceUrl,
+	getErrorCodeReferenceUrl,
+	isHttpUrl,
+	openExternalUrl,
+} from "./external.ts";
 
 test("accepts only browser-safe HTTP(S) URLs", () => {
 	assert.equal(isHttpUrl(" https://example.com/download "), true);
@@ -28,6 +33,20 @@ test("finds a valid persisted source URL without exposing other URI schemes", ()
 		"http://cdn.example.com/archive.zip",
 	);
 	assert.equal(findHttpSourceUrl({ uri: "file:///tmp/archive.zip" }), "");
+});
+
+test("builds error-code reference URLs only for canonical numeric codes", () => {
+	assert.equal(
+		getErrorCodeReferenceUrl("315"),
+		"https://risuko.app/docs/reference/error-codes#315",
+	);
+	assert.equal(
+		getErrorCodeReferenceUrl(540),
+		"https://risuko.app/docs/reference/error-codes#540",
+	);
+	assert.equal(getErrorCodeReferenceUrl("0"), "");
+	assert.equal(getErrorCodeReferenceUrl("315#other"), "");
+	assert.equal(getErrorCodeReferenceUrl("not-a-code"), "");
 });
 
 test("does not invoke an external opener for invalid URLs", async () => {

--- a/src/renderer/utils/external.ts
+++ b/src/renderer/utils/external.ts
@@ -1,5 +1,8 @@
 import { invoke } from "@tauri-apps/api/core";
 
+const ERROR_CODE_REFERENCE_URL =
+	"https://risuko.app/docs/reference/error-codes";
+
 export function isHttpUrl(value: unknown): value is string {
 	if (typeof value !== "string" || !value.trim()) {
 		return false;
@@ -61,6 +64,19 @@ export function findHttpSourceUrl(value: unknown): string {
 	);
 
 	return candidates.find((candidate) => isHttpUrl(candidate))?.trim() || "";
+}
+
+export function getErrorCodeReferenceUrl(value: unknown): string {
+	const code =
+		typeof value === "number" && Number.isInteger(value)
+			? String(value)
+			: typeof value === "string"
+				? value.trim()
+				: "";
+	if (!/^\d{3}$/.test(code) || code === "000") {
+		return "";
+	}
+	return `${ERROR_CODE_REFERENCE_URL}#${code}`;
 }
 
 export async function openExternalUrl(value: unknown): Promise<boolean> {

--- a/src/shared/locales/ar/task.ts
+++ b/src/shared/locales/ar/task.ts
@@ -142,6 +142,7 @@ export default {
 	"usenet-repair-partials-unavailable":
 		"الملفات الجزئية غير متاحة. جرّب NZB مختلفًا أو أعد التنزيل باستخدام مزود باكتمال أفضل.",
 	"open-source-url": "فتح رابط المصدر",
+	"open-error-code-reference": "فتح مرجع رموز الأخطاء",
 	"more-actions": "مزيد من الإجراءات",
 	"filter-video": "تحديد ملفات فيديو",
 	"filter-audio": "تحديد ملفات صوتية",

--- a/src/shared/locales/bg/task.ts
+++ b/src/shared/locales/bg/task.ts
@@ -146,6 +146,7 @@ export default {
 	"usenet-repair-partials-unavailable":
 		"Частичните файлове не са налични. Опитайте друг NZB или изтеглете отново от доставчик с по-добра пълнота.",
 	"open-source-url": "Отвори URL на източника",
+	"open-error-code-reference": "Отвори справката за кодовете на грешки",
 	"more-actions": "Още действия",
 	"filter-video": "Избери видео файлове",
 	"filter-audio": "Избери аудио файлове",

--- a/src/shared/locales/ca/task.ts
+++ b/src/shared/locales/ca/task.ts
@@ -151,6 +151,7 @@ export default {
 	"usenet-repair-partials-unavailable":
 		"Els fitxers parcials no estan disponibles. Proveu un NZB diferent o torneu a baixar-los amb un proveïdor amb una completitud millor.",
 	"open-source-url": "Obre l'URL d'origen",
+	"open-error-code-reference": "Obre la referència dels codis d'error",
 	"more-actions": "Més accions",
 	"filter-video": "Selecciona fitxers de vídeo",
 	"filter-audio": "Selecciona fitxers d'àudio",

--- a/src/shared/locales/de/task.ts
+++ b/src/shared/locales/de/task.ts
@@ -150,6 +150,7 @@ export default {
 	"usenet-repair-partials-unavailable":
 		"Teilweise Dateien sind nicht verfügbar. Versuchen Sie ein anderes NZB oder laden Sie erneut mit einem Anbieter mit besserer Vollständigkeit herunter.",
 	"open-source-url": "Quell-URL öffnen",
+	"open-error-code-reference": "Fehlercode-Referenz öffnen",
 	"more-actions": "Weitere Aktionen",
 	"filter-video": "Videodateien auswählen",
 	"filter-audio": "Audiodateien auswählen",

--- a/src/shared/locales/el/task.ts
+++ b/src/shared/locales/el/task.ts
@@ -151,6 +151,7 @@ export default {
 	"usenet-repair-partials-unavailable":
 		"Τα μερικά αρχεία δεν είναι διαθέσιμα. Δοκιμάστε διαφορετικό NZB ή κατεβάστε ξανά με πάροχο καλύτερης πληρότητας.",
 	"open-source-url": "Άνοιγμα URL προέλευσης",
+	"open-error-code-reference": "Άνοιγμα αναφοράς κωδικών σφάλματος",
 	"more-actions": "Περισσότερες ενέργειες",
 	"filter-video": "Επιλογή αρχείων βίντεο",
 	"filter-audio": "Επιλογή αρχείων ήχου",

--- a/src/shared/locales/en-US/task.ts
+++ b/src/shared/locales/en-US/task.ts
@@ -239,6 +239,7 @@ export default {
 	"no-task": "There are no current tasks",
 	"copy-link": "Copy Link",
 	"open-source-url": "Open source URL",
+	"open-error-code-reference": "Open error-code reference",
 	"copy-link-success": "Successfully copied link",
 	"copy-link-failed": "Failed to copy link",
 	"remove-record": "Remove Task Record",

--- a/src/shared/locales/es/task.ts
+++ b/src/shared/locales/es/task.ts
@@ -149,6 +149,7 @@ export default {
 	"usenet-repair-partials-unavailable":
 		"Los archivos parciales no están disponibles. Prueba con otro NZB o descarga de nuevo con un proveedor con mejor completitud.",
 	"open-source-url": "Abrir URL de origen",
+	"open-error-code-reference": "Abrir referencia de códigos de error",
 	"more-actions": "Más acciones",
 	"filter-video": "Seleccionar archivos de vídeo",
 	"filter-audio": "Seleccionar archivos de audio",

--- a/src/shared/locales/fa/task.ts
+++ b/src/shared/locales/fa/task.ts
@@ -143,6 +143,7 @@ export default {
 	"usenet-repair-partials-unavailable":
 		"فایل‌های ناقص در دسترس نیستند. NZB دیگری را امتحان کنید یا با ارائه‌دهنده‌ای با تکمیل بهتر دوباره دانلود کنید.",
 	"open-source-url": "باز کردن نشانی منبع",
+	"open-error-code-reference": "باز کردن مرجع کدهای خطا",
 	"more-actions": "عملیات بیشتر",
 	"filter-video": "انتخاب فایل ویدئو",
 	"filter-audio": "انتخاب فایل صوتی",

--- a/src/shared/locales/fr/task.ts
+++ b/src/shared/locales/fr/task.ts
@@ -145,6 +145,7 @@ export default {
 	"usenet-repair-partials-unavailable":
 		"Les fichiers partiels ne sont pas disponibles. Essayez un autre NZB ou téléchargez à nouveau avec un fournisseur offrant une meilleure complétude.",
 	"open-source-url": "Ouvrir l’URL source",
+	"open-error-code-reference": "Ouvrir la référence des codes d’erreur",
 	"more-actions": "Plus d’actions",
 	"filter-video": "Sélectionner fichiers vidéo",
 	"filter-audio": "Sélectionner fichiers audio",

--- a/src/shared/locales/hu/task.ts
+++ b/src/shared/locales/hu/task.ts
@@ -141,6 +141,7 @@ export default {
 	"usenet-repair-partials-unavailable":
 		"A részleges fájlok nem érhetők el. Próbáljon másik NZB-t, vagy töltse le újra jobb teljességű szolgáltatón keresztül.",
 	"open-source-url": "Forrás URL megnyitása",
+	"open-error-code-reference": "Hibakód-referencia megnyitása",
 	"more-actions": "További műveletek",
 	"filter-video": "Kijelölés videófájlok",
 	"filter-audio": "Kijelölés hangfájlok",

--- a/src/shared/locales/id/task.ts
+++ b/src/shared/locales/id/task.ts
@@ -145,6 +145,7 @@ export default {
 	"usenet-repair-partials-unavailable":
 		"Berkas parsial tidak tersedia. Coba NZB lain atau unduh kembali dengan penyedia yang memiliki kelengkapan lebih baik.",
 	"open-source-url": "Buka URL sumber",
+	"open-error-code-reference": "Buka referensi kode kesalahan",
 	"more-actions": "Tindakan lainnya",
 	"filter-video": "Pilih berkas video",
 	"filter-audio": "Pilih berkas audio",

--- a/src/shared/locales/it/task.ts
+++ b/src/shared/locales/it/task.ts
@@ -149,6 +149,7 @@ export default {
 	"usenet-repair-partials-unavailable":
 		"I file parziali non sono disponibili. Prova un NZB diverso o scarica di nuovo con un provider con una completezza migliore.",
 	"open-source-url": "Apri URL sorgente",
+	"open-error-code-reference": "Apri il riferimento ai codici di errore",
 	"more-actions": "Altre azioni",
 	"filter-video": "Seleziona file video",
 	"filter-audio": "Seleziona file audio",

--- a/src/shared/locales/ja/task.ts
+++ b/src/shared/locales/ja/task.ts
@@ -146,6 +146,7 @@ export default {
 	"usenet-repair-partials-unavailable":
 		"部分ファイルを利用できません。別の NZB を試すか、より完全性の高いプロバイダーで再度ダウンロードしてください。",
 	"open-source-url": "ソースURLを開く",
+	"open-error-code-reference": "エラーコードのリファレンスを開く",
 	"more-actions": "その他の操作",
 	"filter-video": "動画ファイルを選択",
 	"filter-audio": "音声ファイルを選択",

--- a/src/shared/locales/ko/task.ts
+++ b/src/shared/locales/ko/task.ts
@@ -145,6 +145,7 @@ export default {
 	"usenet-repair-partials-unavailable":
 		"부분 파일을 사용할 수 없습니다. 다른 NZB를 시도하거나 완성도가 더 높은 제공자를 통해 다시 다운로드하세요.",
 	"open-source-url": "소스 URL 열기",
+	"open-error-code-reference": "오류 코드 참조 열기",
 	"more-actions": "추가 작업",
 	"filter-video": "선택 동영상 파일",
 	"filter-audio": "선택 오디오 파일",

--- a/src/shared/locales/nb/task.ts
+++ b/src/shared/locales/nb/task.ts
@@ -148,6 +148,7 @@ export default {
 	"usenet-repair-partials-unavailable":
 		"Delvise filer er ikke tilgjengelige. Prøv en annen NZB, eller last ned på nytt med en leverandør med bedre fullstendighet.",
 	"open-source-url": "Åpne kilde-URL",
+	"open-error-code-reference": "Åpne referanse for feilkoder",
 	"more-actions": "Flere handlinger",
 	"filter-video": "Velg videofiler",
 	"filter-audio": "Velg lydfiler",

--- a/src/shared/locales/nl/task.ts
+++ b/src/shared/locales/nl/task.ts
@@ -150,6 +150,7 @@ export default {
 	"usenet-repair-partials-unavailable":
 		"Gedeeltelijke bestanden zijn niet beschikbaar. Probeer een andere NZB of download opnieuw met een provider met een betere volledigheid.",
 	"open-source-url": "Bron-URL openen",
+	"open-error-code-reference": "Foutcodereferentie openen",
 	"more-actions": "Meer acties",
 	"filter-video": "Selecteren videobestanden",
 	"filter-audio": "Selecteren audiobestanden",

--- a/src/shared/locales/pl/task.ts
+++ b/src/shared/locales/pl/task.ts
@@ -149,6 +149,7 @@ export default {
 	"usenet-repair-partials-unavailable":
 		"Pliki częściowe są niedostępne. Spróbuj innego NZB lub pobierz ponownie od dostawcy z lepszą kompletnością.",
 	"open-source-url": "Otwórz URL źródła",
+	"open-error-code-reference": "Otwórz opis kodu błędu",
 	"more-actions": "Więcej działań",
 	"filter-video": "Wybierz pliki wideo",
 	"filter-audio": "Wybierz pliki audio",

--- a/src/shared/locales/pt-BR/task.ts
+++ b/src/shared/locales/pt-BR/task.ts
@@ -149,6 +149,7 @@ export default {
 	"usenet-repair-partials-unavailable":
 		"Os arquivos parciais não estão disponíveis. Tente outro NZB ou baixe novamente com um provedor com melhor completude.",
 	"open-source-url": "Abrir URL de origem",
+	"open-error-code-reference": "Abrir referência dos códigos de erro",
 	"more-actions": "Mais ações",
 	"filter-video": "Selecionar arquivos de vídeo",
 	"filter-audio": "Selecionar arquivos de áudio",

--- a/src/shared/locales/ro/task.ts
+++ b/src/shared/locales/ro/task.ts
@@ -150,6 +150,7 @@ export default {
 	"usenet-repair-partials-unavailable":
 		"Fișierele parțiale nu sunt disponibile. Încercați un NZB diferit sau descărcați din nou de la un furnizor cu o completitudine mai bună.",
 	"open-source-url": "Deschide URL-ul sursă",
+	"open-error-code-reference": "Deschide referința codurilor de eroare",
 	"more-actions": "Mai multe acțiuni",
 	"filter-video": "Selectează fișiere video",
 	"filter-audio": "Selectează fișiere audio",

--- a/src/shared/locales/ru/task.ts
+++ b/src/shared/locales/ru/task.ts
@@ -147,6 +147,7 @@ export default {
 	"usenet-repair-partials-unavailable":
 		"Частичные файлы недоступны. Попробуйте другой NZB или загрузите снова через провайдера с лучшей полнотой.",
 	"open-source-url": "Открыть URL источника",
+	"open-error-code-reference": "Открыть справочник кодов ошибок",
 	"more-actions": "Другие действия",
 	"filter-video": "Выбрать видеофайлы",
 	"filter-audio": "Выбрать аудиофайлы",

--- a/src/shared/locales/th/task.ts
+++ b/src/shared/locales/th/task.ts
@@ -138,6 +138,7 @@ export default {
 	"usenet-repair-partials-unavailable":
 		"ไฟล์บางส่วนไม่พร้อมใช้งาน ลองใช้ NZB อื่นหรือดาวน์โหลดอีกครั้งผ่านผู้ให้บริการที่มีความสมบูรณ์ดีกว่า",
 	"open-source-url": "เปิด URL ต้นทาง",
+	"open-error-code-reference": "เปิดข้อมูลอ้างอิงรหัสข้อผิดพลาด",
 	"more-actions": "การทำงานเพิ่มเติม",
 	"filter-video": "เลือก ไฟล์วิดีโอ",
 	"filter-audio": "เลือก ไฟล์เสียง",

--- a/src/shared/locales/tr/task.ts
+++ b/src/shared/locales/tr/task.ts
@@ -147,6 +147,7 @@ export default {
 	"usenet-repair-partials-unavailable":
 		"Kısmi dosyalar kullanılamıyor. Farklı bir NZB deneyin veya tamamlanma oranı daha yüksek bir sağlayıcıyla yeniden indirin.",
 	"open-source-url": "Kaynak URL'yi aç",
+	"open-error-code-reference": "Hata kodu başvurusunu aç",
 	"more-actions": "Diğer işlemler",
 	"filter-video": "Seç video dosyaları",
 	"filter-audio": "Seç ses dosyaları",

--- a/src/shared/locales/uk/task.ts
+++ b/src/shared/locales/uk/task.ts
@@ -147,6 +147,7 @@ export default {
 	"usenet-repair-partials-unavailable":
 		"Часткові файли недоступні. Спробуйте інший NZB або завантажте знову через провайдера з кращою повнотою.",
 	"open-source-url": "Відкрити URL джерела",
+	"open-error-code-reference": "Відкрити довідник кодів помилок",
 	"more-actions": "Інші дії",
 	"filter-video": "Вибрати відеофайли",
 	"filter-audio": "Вибрати аудіофайли",

--- a/src/shared/locales/vi/task.ts
+++ b/src/shared/locales/vi/task.ts
@@ -146,6 +146,7 @@ export default {
 	"usenet-repair-partials-unavailable":
 		"Các tệp một phần không khả dụng. Hãy thử NZB khác hoặc tải lại với nhà cung cấp có độ hoàn thiện tốt hơn.",
 	"open-source-url": "Mở URL nguồn",
+	"open-error-code-reference": "Mở tài liệu tham chiếu mã lỗi",
 	"more-actions": "Thao tác khác",
 	"filter-video": "Chọn tệp video",
 	"filter-audio": "Chọn tệp âm thanh",

--- a/src/shared/locales/zh-CN/task.ts
+++ b/src/shared/locales/zh-CN/task.ts
@@ -308,6 +308,7 @@ export default {
 	"usenet-repair-partials-unavailable":
 		"部分文件不可用。请尝试其他 NZB，或使用完整度更高的提供商重新下载。",
 	"open-source-url": "打开源 URL",
+	"open-error-code-reference": "打开错误代码参考",
 	"more-actions": "更多操作",
 	"filter-video": "选择 视频文件",
 	"filter-audio": "选择 音频文件",

--- a/src/shared/locales/zh-TW/task.ts
+++ b/src/shared/locales/zh-TW/task.ts
@@ -313,6 +313,7 @@ export default {
 	"clipboard-download-accept": "下載",
 	"clipboard-download-ignore": "忽略",
 	"open-source-url": "開啟來源 URL",
+	"open-error-code-reference": "開啟錯誤代碼參考",
 	"more-actions": "更多操作",
 	"filter-video": "選取 影片檔案",
 	"filter-audio": "選取 音訊檔案",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a direct “Open error-code reference” action on errors so users can jump to the docs for that code. Also improves the Health header layout on small screens and Android.

- **New Features**
  - Added getErrorCodeReferenceUrl to build safe links for canonical 3‑digit codes; wired into error toasts and Task Detail; added unit tests.
  - New “Open error-code reference” button appears when a canonical code exists; added `task.open-error-code-reference` across locales.
  - Replaced raw URLs in error toasts with the action button; removed the old “Open source URL” button from batch item errors.

- **Bug Fixes**
  - Hide the error-code reference button in the Cloudflare dialog.

<sup>Written for commit b0ef3aa116a862eded49a07e7e352298eb4d4d6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/YueMiyuki/Risuko/pull/141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

